### PR TITLE
Polymede to GMM compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,6 @@ version = "0.1.0"
 dependencies = [
  "bimap",
  "clap",
- "compiler",
  "string-interner",
 ]
 
@@ -135,6 +134,7 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 name = "compiler"
 version = "0.1.0"
 dependencies = [
+ "ast",
  "wasm",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.8"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.8"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
 dependencies = [
  "anstream",
  "anstyle",
@@ -135,6 +135,7 @@ name = "compiler"
 version = "0.1.0"
 dependencies = [
  "ast",
+ "clap",
  "wasm",
 ]
 

--- a/ast/Cargo.toml
+++ b/ast/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2021"
 [dependencies]
 bimap = "0.6.3"
 clap = { version = "4.5.8", features = ["derive"] }
-compiler = { path = "../compiler" }
 string-interner = "0.17.0"

--- a/ast/src/base.rs
+++ b/ast/src/base.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 #[derive(Debug)]
 pub struct Program {
     interner: Interner,
-    pub type_declarations: HashMap<ConstructorName, TypeDeclaration>,
+    pub type_declarations: HashMap<Variable, TypeDeclaration>,
     pub function_declarations: HashMap<FunctionName, FunctionDeclaration>,
     pub let_declarations: HashMap<Variable, LetDeclaration>,
     pub constructor_to_type_mapping: HashMap<ConstructorName, Variable>,
@@ -209,6 +209,14 @@ impl TypeDeclaration {
         match self {
             Enum(decl) => decl.type_apply_constructor(constructor_name, type_args),
             Ind(decl) => decl.type_apply_constructor(constructor_name, type_args, &Type::TypeApplication(self.name().clone(), type_args.to_vec())),
+        }
+    }
+
+    pub fn constructors(&self) -> &HashMap<ConstructorName, ConstructorDeclaration> {
+        use TypeDeclaration::*;
+        match self {
+            Enum(decl) => &decl.constructors,
+            Ind(decl) => &decl.constructors,
         }
     }
 }

--- a/ast/src/base.rs
+++ b/ast/src/base.rs
@@ -45,7 +45,7 @@ impl Program {
 
     pub fn get_type_declaration_of_constructor(&self, constructor_name: &ConstructorName) -> Option<&TypeDeclaration> {
         let type_name = self.constructor_to_type_mapping.get(constructor_name)?;
-        self.get_type_declaration_of_constructor(type_name)
+        self.get_type_declaration(type_name)
     }
 
     pub fn type_declarations_in_source_ordering(&self) -> Vec<&TypeDeclaration> {

--- a/ast/src/base.rs
+++ b/ast/src/base.rs
@@ -1,0 +1,313 @@
+use crate::identifier::{Interner, interner, Variable, ConstructorName, FunctionName, Identifier};
+use crate::parser::base::PreTypeDeclaration;
+use std::collections::HashMap;
+
+// ===Program===
+#[derive(Debug)]
+pub struct Program {
+    interner: Interner,
+    pub type_declarations: HashMap<ConstructorName, TypeDeclaration>,
+    pub function_declarations: HashMap<FunctionName, FunctionDeclaration>,
+    pub let_declarations: HashMap<Variable, LetDeclaration>,
+    pub constructor_to_type_mapping: HashMap<ConstructorName, Variable>,
+}
+
+impl Program {
+    pub fn new() -> Self {
+        Self { 
+            interner: interner(),
+            type_declarations: HashMap::new(),
+            function_declarations: HashMap::new(),
+            let_declarations: HashMap::new(),
+            constructor_to_type_mapping: HashMap::new(),
+        }
+    }
+
+    pub fn interner(&self) -> &Interner {
+        &self.interner
+    }
+
+    pub fn interner_mut(&mut self) -> &mut Interner {
+        &mut self.interner
+    }
+
+    pub fn get_type_declaration(&self, type_name: &Variable) -> Option<&TypeDeclaration> {
+        self.type_declarations.get(type_name)
+    }
+
+    pub fn get_function_declaration(&self, function_name: &FunctionName) -> Option<&FunctionDeclaration> {
+        self.function_declarations.get(function_name)
+    }
+
+    pub fn get_type_declaration_of_constructor(&self, constructor_name: &ConstructorName) -> Option<&TypeDeclaration> {
+        let type_name = self.constructor_to_type_mapping.get(constructor_name)?;
+        self.get_type_declaration_of_constructor(type_name)
+    }
+}
+
+
+// ===Declarations===
+#[derive(Debug)]
+pub struct ConstructorDeclaration {
+    pub name: Identifier,
+    pub parameters: Vec<Type>,
+}
+
+#[derive(Debug)]
+pub struct EnumDeclaration {
+    pub name: ConstructorName,
+    pub type_parameters: Vec<Variable>,
+    pub constructors: HashMap<ConstructorName, ConstructorDeclaration>,
+}
+
+#[derive(Debug)]
+pub struct IndDeclaration {
+    pub name: ConstructorName,
+    pub type_parameters: Vec<Variable>,
+    pub recursive_type_var: Variable,
+    pub constructors: HashMap<ConstructorName, ConstructorDeclaration>,
+}
+
+#[derive(Debug)]
+pub enum TypeDeclaration {
+    Enum(EnumDeclaration),
+    Ind(IndDeclaration),
+}
+
+#[derive(Debug)]
+pub struct FunctionDeclaration {
+    pub name: FunctionName,
+    pub type_parameters: Vec<Variable>,
+    pub function: TypedFunction,
+}
+
+#[derive(Debug)]
+pub struct TypedFunction {
+    pub type_: FunctionType,
+    pub function: Function,
+}
+
+#[derive(Debug)]
+pub struct Function {
+    pub parameters: Vec<Variable>,
+    pub body: Term,
+}
+
+// TODO: Get rid of this or replace it by a version that doesn't have type parameters.
+#[derive(Debug)]
+pub struct LetDeclaration {
+    pub name: Variable,
+    pub type_parameters: Vec<Variable>,
+    pub body: TypedTerm,
+}
+
+// ===Types===
+#[derive(Debug, PartialEq, Clone)]
+pub enum Type {
+    VariableUse(Variable),
+    TypeApplication(ConstructorName, Vec<Type>),
+    Arrow(Box<FunctionType>),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct FunctionType {
+    pub input_types: Vec<Type>,
+    pub output_type: Type,
+}
+
+
+// ===Terms===
+#[derive(Debug)]
+pub struct TypedTerm {
+    pub type_: Type,
+    pub term: Term
+}
+
+#[derive(Debug)]
+pub enum Term {
+    TypedTerm(Box<TypedTerm>),
+    VariableUse(Variable),
+    FunctionApplication(Variable, Vec<Type>, Vec<Term>),
+    ConstructorUse(ConstructorName, Vec<Term>),
+    Match(Box<Term>, Vec<PatternBranch>),
+    Fold(Box<Term>, Vec<PatternBranch>),
+    Lambda(Box<Function>),
+    LambdaApplication(Box<Term>, Vec<Term>),
+    Let(Vec<(Variable, Term)>, Box<Term>),
+}
+
+#[derive(Debug)]
+pub struct PatternBranch {
+    pub pattern: Pattern,
+    pub body: Term,
+}
+
+#[derive(Debug)]
+pub enum Pattern {
+    Constructor(ConstructorName, Vec<Pattern>),
+    Variable(Variable),
+    Anything(Identifier),
+}
+
+impl TypeDeclaration {
+    pub fn new(pre_decl: PreTypeDeclaration, constructor_to_type_mapping: &mut HashMap<ConstructorName, Variable>) -> Self {
+        match pre_decl {
+            PreTypeDeclaration::Enum(pre_decl) => {
+                let mut constructors = HashMap::new();
+                for constructor_decl in pre_decl.constructors {
+                    constructor_to_type_mapping.insert(constructor_decl.name.clone(), pre_decl.name.clone());
+                    constructors.insert(constructor_decl.name.clone(), constructor_decl);
+                }
+                Self::Enum(EnumDeclaration {
+                    name: pre_decl.name,
+                    type_parameters: pre_decl.type_parameters,
+                    constructors,
+                })
+            },
+            PreTypeDeclaration::Ind(pre_decl) => {
+                let mut constructors = HashMap::new();
+                for constructor_decl in pre_decl.constructors {
+                    constructor_to_type_mapping.insert(constructor_decl.name.clone(), pre_decl.name.clone());
+                    constructors.insert(constructor_decl.name.clone(), constructor_decl);
+                }
+                Self::Ind(IndDeclaration {
+                    name: pre_decl.name,
+                    recursive_type_var: pre_decl.recursive_type_var,
+                    type_parameters: pre_decl.type_parameters,
+                    constructors,
+                })
+            }
+        }
+    }
+
+    pub fn name(&self) -> &ConstructorName {
+        use TypeDeclaration::*;
+        match self {
+            Enum(decl) => &decl.name,
+            Ind(decl) => &decl.name,
+        }
+    }
+
+    pub fn arity(&self) -> usize {
+        use TypeDeclaration::*;
+        match self {
+            Enum(decl) => decl.type_parameters.len(),
+            Ind(decl) => decl.type_parameters.len(),
+        }
+    }
+
+    // WARNING: Assumes number of elements of `type_args` matches arity of the constructor.
+    // e.g. consider type declaration
+    //   type BinTree(a, b) = ind { tree .
+    //   | Leaf(a)
+    //   | Branch(b, Fn(Two -> tree))
+    //   }
+    // then type-applying the type arguments [Bool, Int] to the Branch constructor leads to
+    //   Branch(Int, Fn(Two -> BinTree(Bool, Int)))
+    pub fn type_apply_constructor(&self, constructor_name: &ConstructorName, type_args: &[Type]) -> Option<(&ConstructorDeclaration, Vec<Type>)> {
+        use TypeDeclaration::*;
+        match self {
+            Enum(decl) => decl.type_apply_constructor(constructor_name, type_args),
+            Ind(decl) => decl.type_apply_constructor(constructor_name, type_args, &Type::TypeApplication(self.name().clone(), type_args.to_vec())),
+        }
+    }
+}
+
+impl EnumDeclaration {
+    pub fn type_apply_constructor(&self, constructor_name: &ConstructorName, type_args: &[Type]) -> Option<(&ConstructorDeclaration, Vec<Type>)> {
+        let constructor_decl = self.constructors.get(constructor_name)?;
+        let specialized_constructor_type_arguments: Vec<Type> = constructor_decl.parameters
+            .iter()
+            .map(|type_body| type_apply(&self.type_parameters, type_body, type_args))
+            .collect();
+        Some((constructor_decl, specialized_constructor_type_arguments))
+    }
+}
+
+impl IndDeclaration {
+    pub fn type_apply_constructor(&self, constructor_name: &ConstructorName, type_args: &[Type], recursive_type: &Type) -> Option<(&ConstructorDeclaration, Vec<Type>)> {
+        let constructor_decl = self.constructors.get(constructor_name)?;
+
+        // TODO: This assumes that type_parameters + rec_type_var are all unique, and that
+        // the rec_type_var doesn't shadow anything. But I don't yet check this!
+        let mut type_parameters: Vec<Variable> = self.type_parameters.to_vec();
+        type_parameters.push(self.recursive_type_var.clone());
+
+        let mut type_args: Vec<Type> = type_args.to_vec();
+        type_args.push(recursive_type.clone());
+
+        let specialized_constructor_type_arguments: Vec<Type> = constructor_decl.parameters
+            .iter()
+            .map(|type_body| type_apply(&type_parameters, type_body, &type_args))
+            .collect();
+        Some((constructor_decl, specialized_constructor_type_arguments))
+    }
+}
+
+impl FunctionDeclaration {
+    pub fn name(&self) -> FunctionName {
+        self.name.clone()
+    }
+
+    pub fn type_arity(&self) -> usize {
+        self.type_parameters.len()
+    }
+
+    // Assumes arity matches.
+    pub fn type_apply(&self, type_arguments: &[Type]) -> FunctionType {
+        // TODO: This can be pretty space-expensive substitution. Consider having proper closures as type
+        //       expressions.
+        FunctionType {
+            input_types: self.function.type_.input_types.iter().map(|type_| type_apply(&self.type_parameters, type_, type_arguments)).collect(),
+            output_type: type_apply(&self.type_parameters, &self.function.type_.output_type, type_arguments)
+        }
+    }
+}
+
+impl LetDeclaration {
+    pub fn name(&self) -> Variable {
+        self.name.clone()
+    }
+}
+
+impl ConstructorDeclaration {
+    pub fn arity(&self) -> usize { 
+        self.parameters.len()
+    }
+}
+
+pub fn type_apply(type_parameters: &[Variable], type_body: &Type, type_arguments: &[Type]) -> Type {
+    // TODO: What are the assumptions? Am I responsible for checking the arities are correct here?
+    //
+    // given a variable in type_body, I need to know which argument to substitute...
+    // So I actually need to have Variable ~> index mapping...
+    //
+    // This is not very efficient.
+    let mut position_map: HashMap<&Variable, usize> = HashMap::new();
+    for (i, var) in type_parameters.iter().enumerate() {
+        position_map.insert(var, i);
+    }
+    
+    fn traverse(position_map: &HashMap<&Variable, usize>, type_body: &Type, type_arguments: &[Type]) -> Type {
+        use Type::*;
+        match type_body {
+            VariableUse(var) => {
+                match position_map.get(var) {
+                    Some(i) => type_arguments[*i].clone(),
+                    None => unreachable!(),
+                }
+            },
+            TypeApplication(type_name, args) => {
+                let applied_args: Vec<Type> = args.into_iter().map(|type_| traverse(position_map, type_, type_arguments)).collect();
+                TypeApplication(type_name.clone(), applied_args)
+            }
+            Arrow(fn_type) => {
+                let applied_input_types: Vec<Type> = fn_type.input_types.iter().map(|type_| traverse(position_map, type_, type_arguments)).collect();
+                let applied_output_type = traverse(position_map, &fn_type.output_type, type_arguments);
+                Arrow(Box::new(FunctionType { input_types: applied_input_types, output_type: applied_output_type }))
+            },
+        }
+    }
+
+    traverse(&position_map, type_body, type_arguments)
+}

--- a/ast/src/identifier.rs
+++ b/ast/src/identifier.rs
@@ -1,0 +1,75 @@
+use crate::parser::lex::lexer::Position;
+use std::hash::{Hash, Hasher};
+
+use string_interner::{
+    StringInterner,
+    backend::StringBackend,
+    DefaultSymbol,
+};
+
+pub type Interner = StringInterner<StringBackend>;
+pub type Symbol = DefaultSymbol;
+
+pub fn interner() -> Interner {
+    StringInterner::default()
+}
+
+#[derive(Debug, Clone)]
+pub struct Identifier {
+    symbol: Symbol,
+    position: Position,
+}
+
+// Identifier that starts with lowercase letter.
+pub type Variable = Identifier;
+pub type FunctionName = Variable;
+// Identifier that starts with uppercase letter.
+pub type ConstructorName = Identifier;
+
+impl Identifier {
+    pub fn new(str: String, position: Position, interner: &mut Interner) -> Self {
+        let symbol = interner.get_or_intern(str);
+        Self { symbol, position }
+    }
+
+    pub fn str<'interner: 'id, 'id>(&'id self, interner: &'interner Interner) -> &'id str {
+        match interner.resolve(self.symbol) {
+            Some(str) => str,
+            None => unreachable!()
+        }
+    }
+
+    pub fn first_char(&self, state: &Interner) -> char {
+        // identifier is guaranteed to be non-empty
+        let c = self.str(state).chars().nth(0).unwrap();
+        c
+    }
+}
+
+impl PartialEq for Identifier {
+    fn eq(&self, other: &Self) -> bool {
+        self.symbol == other.symbol
+    }
+}
+
+impl Eq for Identifier {}
+
+impl Hash for Identifier {
+    fn hash<H>(&self, state: &mut H) where H: Hasher {
+        self.symbol.hash(state)
+    }
+}
+ 
+pub fn duplicates(identifiers: &[Identifier]) -> Vec<Identifier> {
+    use std::collections::HashSet;
+    let mut seen: HashSet<&Identifier> = HashSet::new();
+    let mut duplicates: Vec<Identifier> = vec![];
+
+    for id in identifiers {
+        if !seen.insert(id) {
+            // id was already present.
+            duplicates.push(id.clone());
+        }
+    }
+    duplicates
+}

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -1,0 +1,4 @@
+mod parser;
+pub mod validation;
+pub mod identifier;
+pub mod base;

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -1,4 +1,4 @@
-mod parser;
+pub mod parser;
 pub mod validation;
 pub mod identifier;
 pub mod base;

--- a/ast/src/main.rs
+++ b/ast/src/main.rs
@@ -1,8 +1,9 @@
 mod parser;
 mod validation;
+mod base;
+mod identifier;
 
 use std::io;
-use std::io::Write;
 use std::fs;
 use clap::Parser;
 
@@ -15,7 +16,7 @@ struct Args {
     file: String,
 }
 
-fn check_program(program: &parser::base::Program) -> Result<(), Vec<validation::base::ErrorWithLocation>> {
+fn check_program(program: &base::Program) -> Result<(), Vec<validation::base::ErrorWithLocation>> {
     validation::type_formation::check_program(&program)?;
     validation::term_formation::check_program(&program)?;
     Ok(())

--- a/ast/src/main.rs
+++ b/ast/src/main.rs
@@ -8,7 +8,6 @@ use std::fs;
 use clap::Parser;
 
 
-// Simple program to greet a person
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {

--- a/ast/src/parser/base.rs
+++ b/ast/src/parser/base.rs
@@ -46,9 +46,11 @@ pub fn parse_program(s: &str) -> Result<Program> {
 
     for pre_decl in pre_program.type_declarations {
         let decl = TypeDeclaration::new(pre_decl,  &mut program.constructor_to_type_mapping);
+        program.type_declarations_ordering.push(decl.name().clone());
         program.type_declarations.insert(decl.name().clone(), decl);
     }
     for decl in pre_program.function_declarations {
+        program.function_declarations_ordering.push(decl.name());
         program.function_declarations.insert(decl.name(), decl);
     }
     for decl in pre_program.let_declarations {

--- a/ast/src/parser/base.rs
+++ b/ast/src/parser/base.rs
@@ -1,13 +1,11 @@
+use crate::base::{ Program, TypeDeclaration, LetDeclaration, FunctionDeclaration, ConstructorDeclaration};
+use crate::identifier::{Interner, Variable, ConstructorName, FunctionName, Identifier};
 use crate::parser::lex::{
     lexer,
     lexer::{Request, LocatedToken, DeclarationKind},
     token::Keyword,
 };
-use crate::parser::{
-    program::pre_program,
-    identifier::{Interner, interner, Variable, ConstructorName, FunctionName, Identifier}
-};
-use std::collections::HashMap;
+use crate::parser::program::pre_program;
 
 pub type Result<A> = std::result::Result<A, Error>;
 
@@ -24,7 +22,6 @@ pub enum Error {
     ExpectedTypeConstructorOrTypeVarOrAnythingInPattern { received: Identifier },
     ExpectedTerm { received: Identifier },
     ExpectedTypeConstructor { received: Identifier },
-    ExpectedTypeVar { received: Identifier },
     DuplicateVariableNames { duplicates: Vec<Identifier> },
     // Atleast one vector is non-empty.
     DuplicateNames {
@@ -36,72 +33,36 @@ pub enum Error {
     FunctionHasDifferentNumberOfParametersThanDeclaredInItsType { declared_in_type: usize, parameters: usize },
 }
 
-
 #[derive(Debug)]
 pub struct State<'lex_state, 'interner> {
     lexer_state: lexer::State<'lex_state>,
     interner: &'interner mut Interner,
 }
 
-// ===Program===
-#[derive(Debug)]
-pub struct Program {
-    interner: Interner,
-    pub type_declarations: HashMap<ConstructorName, TypeDeclaration>,
-    pub function_declarations: HashMap<FunctionName, FunctionDeclaration>,
-    pub let_declarations: HashMap<Variable, LetDeclaration>,
-    constructor_to_type_mapping: HashMap<ConstructorName, Variable>,
+pub fn parse_program(s: &str) -> Result<Program> {
+    let mut program = Program::new();
+    let mut state = State::new(s, program.interner_mut());
+    let pre_program = pre_program(&mut state)?;
+
+    for pre_decl in pre_program.type_declarations {
+        let decl = TypeDeclaration::new(pre_decl,  &mut program.constructor_to_type_mapping);
+        program.type_declarations.insert(decl.name().clone(), decl);
+    }
+    for decl in pre_program.function_declarations {
+        program.function_declarations.insert(decl.name(), decl);
+    }
+    for decl in pre_program.let_declarations {
+        program.let_declarations.insert(decl.name(), decl);
+    }
+
+    Ok(program)
 }
 
-impl Program {
-    pub fn interner(&self) -> &Interner {
-        &self.interner
-    }
-
-    pub fn parse(s: &str) -> Result<Self> {
-        let mut interner: Interner = interner();
-        let mut state = State::new(s, &mut interner);
-        let pre_program = pre_program(&mut state)?;
-        let mut program = Self {
-            interner,
-            type_declarations: HashMap::new(),
-            function_declarations: HashMap::new(),
-            let_declarations: HashMap::new(),
-            constructor_to_type_mapping: HashMap::new(),
-        };
-
-        for pre_decl in pre_program.type_declarations {
-            let decl = TypeDeclaration::new(pre_decl,  &mut program.constructor_to_type_mapping);
-            program.type_declarations.insert(decl.name().clone(), decl);
-        }
-        for decl in pre_program.function_declarations {
-            program.function_declarations.insert(decl.name(), decl);
-        }
-        for decl in pre_program.let_declarations {
-            program.let_declarations.insert(decl.name(), decl);
-        }
-
-        Ok(program)
-    }
-
-    pub fn get_type_declaration(&self, type_name: &Variable) -> Option<&TypeDeclaration> {
-        self.type_declarations.get(type_name)
-    }
-
-    pub fn get_function_declaration(&self, function_name: &FunctionName) -> Option<&FunctionDeclaration> {
-        self.function_declarations.get(function_name)
-    }
-
-    pub fn get_let_declaration(&self, let_name: &FunctionName) -> Option<&LetDeclaration> {
-        self.let_declarations.get(let_name)
-    }
-
-    pub fn get_type_declaration_of_constructor(&self, constructor_name: &ConstructorName) -> Option<&TypeDeclaration> {
-        let type_name = self.constructor_to_type_mapping.get(constructor_name)?;
-        self.get_type_declaration_of_constructor(type_name)
-    }
+pub enum Declaration {
+    Type(PreTypeDeclaration),
+    Let(LetDeclaration),
+    Function(FunctionDeclaration),
 }
-
 
 #[derive(Debug)]
 pub struct PreProgram {
@@ -110,39 +71,11 @@ pub struct PreProgram {
     pub let_declarations: Vec<LetDeclaration>,
 }
 
-// ===Declarations===
-pub enum Declaration {
-    Type(PreTypeDeclaration),
-    Let(LetDeclaration),
-    Function(FunctionDeclaration),
-}
-
-#[derive(Debug)]
-pub struct ConstructorDeclaration {
-    pub name: Identifier,
-    pub parameters: Vec<Type>,
-}
-
-#[derive(Debug)]
-pub struct EnumDeclaration {
-    pub name: ConstructorName,
-    pub type_parameters: Vec<Variable>,
-    pub constructors: HashMap<ConstructorName, ConstructorDeclaration>,
-}
-
 #[derive(Debug)]
 pub struct PreEnumDeclaration {
     pub name: ConstructorName,
     pub type_parameters: Vec<Variable>,
     pub constructors: Vec<ConstructorDeclaration>,
-}
-
-#[derive(Debug)]
-pub struct IndDeclaration {
-    pub name: ConstructorName,
-    pub type_parameters: Vec<Variable>,
-    pub recursive_type_var: Variable,
-    pub constructors: HashMap<ConstructorName, ConstructorDeclaration>,
 }
 
 #[derive(Debug)]
@@ -154,227 +87,9 @@ pub struct PreIndDeclaration {
 }
 
 #[derive(Debug)]
-pub enum TypeDeclaration {
-    Enum(EnumDeclaration),
-    Ind(IndDeclaration),
-}
-
-#[derive(Debug)]
 pub enum PreTypeDeclaration {
     Enum(PreEnumDeclaration),
     Ind(PreIndDeclaration),
-}
-
-impl EnumDeclaration {
-    // Returns type_parameters together with declaration.
-    pub fn get_constructor(&self, constructor_name: &ConstructorName) -> Option<(&[Variable], &ConstructorDeclaration)> {
-        let constructor_decl = self.constructors.get(constructor_name)?;
-        Some((&self.type_parameters, constructor_decl))
-    }
-}
-
-impl IndDeclaration {
-    // Returns type_parameters (and a special recursive variable) together with declaration.
-    pub fn get_constructor(&self, constructor_name: &ConstructorName) -> Option<(&[Variable], &Variable, &ConstructorDeclaration)> {
-        let constructor_decl = self.constructors.get(constructor_name)?;
-        Some((&self.type_parameters, &self.recursive_type_var, constructor_decl))
-    }
-}
-
-impl TypeDeclaration {
-    fn new(pre_decl: PreTypeDeclaration, constructor_to_type_mapping: &mut HashMap<ConstructorName, Variable>) -> Self {
-        match pre_decl {
-            PreTypeDeclaration::Enum(pre_decl) => {
-                let mut constructors = HashMap::new();
-                for constructor_decl in pre_decl.constructors {
-                    constructor_to_type_mapping.insert(constructor_decl.name.clone(), pre_decl.name.clone());
-                    constructors.insert(constructor_decl.name.clone(), constructor_decl);
-                }
-                Self::Enum(EnumDeclaration {
-                    name: pre_decl.name,
-                    type_parameters: pre_decl.type_parameters,
-                    constructors,
-                })
-            },
-            PreTypeDeclaration::Ind(pre_decl) => {
-                let mut constructors = HashMap::new();
-                for constructor_decl in pre_decl.constructors {
-                    constructor_to_type_mapping.insert(constructor_decl.name.clone(), pre_decl.name.clone());
-                    constructors.insert(constructor_decl.name.clone(), constructor_decl);
-                }
-                Self::Ind(IndDeclaration {
-                    name: pre_decl.name,
-                    recursive_type_var: pre_decl.recursive_type_var,
-                    type_parameters: pre_decl.type_parameters,
-                    constructors,
-                })
-            }
-        }
-    }
-
-    pub fn name(&self) -> &ConstructorName {
-        use TypeDeclaration::*;
-        match self {
-            Enum(decl) => &decl.name,
-            Ind(decl) => &decl.name,
-        }
-    }
-
-    pub fn arity(&self) -> usize {
-        use TypeDeclaration::*;
-        match self {
-            Enum(decl) => decl.type_parameters.len(),
-            Ind(decl) => decl.type_parameters.len(),
-        }
-    }
-
-    // WARNING: Assumes number of elements of `type_args` matches arity of the constructor.
-    // e.g. consider type declaration
-    //   type BinTree(a, b) = ind { tree .
-    //   | Leaf(a)
-    //   | Branch(b, Fn(Two -> tree))
-    //   }
-    // then type-applying the type arguments [Bool, Int] to the Branch constructor leads to
-    //   Branch(Int, Fn(Two -> BinTree(Bool, Int)))
-    pub fn type_apply_constructor(&self, constructor_name: &ConstructorName, type_args: &[Type]) -> Option<(&ConstructorDeclaration, Vec<Type>)> {
-        use TypeDeclaration::*;
-        match self {
-            Enum(decl) => decl.type_apply_constructor(constructor_name, type_args),
-            Ind(decl) => decl.type_apply_constructor(constructor_name, type_args, &Type::TypeApplication(self.name().clone(), type_args.to_vec())),
-        }
-    }
-}
-
-impl EnumDeclaration {
-    pub fn type_apply_constructor(&self, constructor_name: &ConstructorName, type_args: &[Type]) -> Option<(&ConstructorDeclaration, Vec<Type>)> {
-        let constructor_decl = self.constructors.get(constructor_name)?;
-        let specialized_constructor_type_arguments: Vec<Type> = constructor_decl.parameters
-            .iter()
-            .map(|type_body| type_apply(&self.type_parameters, type_body, type_args))
-            .collect();
-        Some((constructor_decl, specialized_constructor_type_arguments))
-    }
-}
-
-impl IndDeclaration {
-    pub fn type_apply_constructor(&self, constructor_name: &ConstructorName, type_args: &[Type], recursive_type: &Type) -> Option<(&ConstructorDeclaration, Vec<Type>)> {
-        let constructor_decl = self.constructors.get(constructor_name)?;
-
-        // TODO: This assumes that type_parameters + rec_type_var are all unique, and that
-        // the rec_type_var doesn't shadow anything. But I don't yet check this!
-        let mut type_parameters: Vec<Variable> = self.type_parameters.to_vec();
-        type_parameters.push(self.recursive_type_var.clone());
-
-        let mut type_args: Vec<Type> = type_args.to_vec();
-        type_args.push(recursive_type.clone());
-
-        let specialized_constructor_type_arguments: Vec<Type> = constructor_decl.parameters
-            .iter()
-            .map(|type_body| type_apply(&type_parameters, type_body, &type_args))
-            .collect();
-        Some((constructor_decl, specialized_constructor_type_arguments))
-    }
-}
-
-#[derive(Debug)]
-pub struct FunctionDeclaration {
-    pub name: FunctionName,
-    pub type_parameters: Vec<Variable>,
-    pub function: TypedFunction,
-}
-
-impl FunctionDeclaration {
-    pub fn name(&self) -> FunctionName {
-        self.name.clone()
-    }
-
-    pub fn type_arity(&self) -> usize {
-        self.type_parameters.len()
-    }
-
-    // Assumes arity matches.
-    pub fn type_apply(&self, type_arguments: &[Type]) -> FunctionType {
-        // TODO: This can be pretty space-expensive substitution. Consider having proper closures as type
-        //       expressions.
-        FunctionType {
-            input_types: self.function.type_.input_types.iter().map(|type_| type_apply(&self.type_parameters, type_, type_arguments)).collect(),
-            output_type: type_apply(&self.type_parameters, &self.function.type_.output_type, type_arguments)
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct TypedFunction {
-    pub type_: FunctionType,
-    pub function: Function,
-}
-
-#[derive(Debug)]
-pub struct Function {
-    pub parameters: Vec<Variable>,
-    pub body: Term,
-}
-
-// TODO: Get rid of this or replace it by a version that doesn't have type parameters.
-#[derive(Debug)]
-pub struct LetDeclaration {
-    pub name: Variable,
-    pub type_parameters: Vec<Variable>,
-    pub body: TypedTerm,
-}
-
-impl LetDeclaration {
-    pub fn name(&self) -> Variable {
-        self.name.clone()
-    }
-}
-
-// ===Types===
-#[derive(Debug, PartialEq, Clone)]
-pub enum Type {
-    VariableUse(Variable),
-    TypeApplication(ConstructorName, Vec<Type>),
-    Arrow(Box<FunctionType>),
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct FunctionType {
-    pub input_types: Vec<Type>,
-    pub output_type: Type,
-}
-
-
-// ===Terms===
-#[derive(Debug)]
-pub struct TypedTerm {
-    pub type_: Type,
-    pub term: Term
-}
-
-#[derive(Debug)]
-pub enum Term {
-    TypedTerm(Box<TypedTerm>),
-    VariableUse(Variable),
-    FunctionApplication(Variable, Vec<Type>, Vec<Term>),
-    ConstructorUse(ConstructorName, Vec<Term>),
-    Match(Box<Term>, Vec<PatternBranch>),
-    Fold(Box<Term>, Vec<PatternBranch>),
-    Lambda(Box<Function>),
-    LambdaApplication(Box<Term>, Vec<Term>),
-    Let(Vec<(Variable, Term)>, Box<Term>),
-}
-
-#[derive(Debug)]
-pub struct PatternBranch {
-    pub pattern: Pattern,
-    pub body: Term,
-}
-
-#[derive(Debug)]
-pub enum Pattern {
-    Constructor(ConstructorName, Vec<Pattern>),
-    Variable(Variable),
-    Anything(Identifier),
 }
 
 impl PreProgram {
@@ -440,49 +155,6 @@ impl PreProgram {
         }
         names
     }
-}
-
-impl ConstructorDeclaration {
-    pub fn arity(&self) -> usize { 
-        self.parameters.len()
-    }
-}
-
-
-pub fn type_apply(type_parameters: &[Variable], type_body: &Type, type_arguments: &[Type]) -> Type {
-    // TODO: What are the assumptions? Am I responsible for checking the arities are correct here?
-    //
-    // given a variable in type_body, I need to know which argument to substitute...
-    // So I actually need to have Variable ~> index mapping...
-    //
-    // This is not very efficient.
-    let mut position_map: HashMap<&Variable, usize> = HashMap::new();
-    for (i, var) in type_parameters.iter().enumerate() {
-        position_map.insert(var, i);
-    }
-    
-    fn traverse(position_map: &HashMap<&Variable, usize>, type_body: &Type, type_arguments: &[Type]) -> Type {
-        use Type::*;
-        match type_body {
-            VariableUse(var) => {
-                match position_map.get(var) {
-                    Some(i) => type_arguments[*i].clone(),
-                    None => unreachable!(),
-                }
-            },
-            TypeApplication(type_name, args) => {
-                let applied_args: Vec<Type> = args.into_iter().map(|type_| traverse(position_map, type_, type_arguments)).collect();
-                TypeApplication(type_name.clone(), applied_args)
-            }
-            Arrow(fn_type) => {
-                let applied_input_types: Vec<Type> = fn_type.input_types.iter().map(|type_| traverse(position_map, type_, type_arguments)).collect();
-                let applied_output_type = traverse(position_map, &fn_type.output_type, type_arguments);
-                Arrow(Box::new(FunctionType { input_types: applied_input_types, output_type: applied_output_type }))
-            },
-        }
-    }
-
-    traverse(&position_map, type_body, type_arguments)
 }
 
 impl <'lex_state, 'interner> State<'lex_state, 'interner> {

--- a/ast/src/parser/identifier.rs
+++ b/ast/src/parser/identifier.rs
@@ -1,34 +1,9 @@
+use crate::identifier::{Identifier, ConstructorName, FunctionName, Variable};
 use crate::parser::lex::{
-    lexer::{Position, LocatedToken, Request},
+    lexer::{LocatedToken, Request},
     token::Token,
 };
 use crate::parser::base::{State, Result, Error};
-use std::hash::{Hash, Hasher};
-
-use string_interner::{
-    StringInterner,
-    backend::StringBackend,
-    DefaultSymbol,
-};
-
-pub type Interner = StringInterner<StringBackend>;
-pub type Symbol = DefaultSymbol;
-
-pub fn interner() -> Interner {
-    StringInterner::default()
-}
-
-#[derive(Debug, Clone)]
-pub struct Identifier {
-    symbol: Symbol,
-    position: Position,
-}
-
-// Identifier that starts with lowercase letter.
-pub type Variable = Identifier;
-pub type FunctionName = Variable;
-// Identifier that starts with uppercase letter.
-pub type ConstructorName = Identifier;
 
 // TODO: These are more appropriate for lexer.
 pub fn identifier(state: &mut State) -> Result<Identifier> {
@@ -51,52 +26,4 @@ pub fn variable(state: &mut State) -> Result<Variable> {
 
 pub fn function_name(state: &mut State) -> Result<FunctionName> {
     variable(state)
-}
-
-impl Identifier {
-    pub fn new(str: String, position: Position, interner: &mut Interner) -> Self {
-        let symbol = interner.get_or_intern(str);
-        Self { symbol, position }
-    }
-
-    pub fn str<'interner: 'id, 'id>(&'id self, interner: &'interner Interner) -> &'id str {
-        match interner.resolve(self.symbol) {
-            Some(str) => str,
-            None => unreachable!()
-        }
-    }
-
-    pub fn first_char(&self, state: &Interner) -> char {
-        // identifier is guaranteed to be non-empty
-        let c = self.str(state).chars().nth(0).unwrap();
-        c
-    }
-}
-
-impl PartialEq for Identifier {
-    fn eq(&self, other: &Self) -> bool {
-        self.symbol == other.symbol
-    }
-}
-
-impl Eq for Identifier {}
-
-impl Hash for Identifier {
-    fn hash<H>(&self, state: &mut H) where H: Hasher {
-        self.symbol.hash(state)
-    }
-}
- 
-pub fn duplicates(identifiers: &[Identifier]) -> Vec<Identifier> {
-    use std::collections::HashSet;
-    let mut seen: HashSet<&Identifier> = HashSet::new();
-    let mut duplicates: Vec<Identifier> = vec![];
-
-    for id in identifiers {
-        if !seen.insert(id) {
-            // id was already present.
-            duplicates.push(id.clone());
-        }
-    }
-    duplicates
 }

--- a/ast/src/parser/lex/lexer.rs
+++ b/ast/src/parser/lex/lexer.rs
@@ -12,12 +12,10 @@ pub struct State<'a> {
 }
 
 #[derive(Debug)]
-// TODO: Introduce Committed vs Recoverable Error
 pub enum Error {
     UnexpectedEnd,
     Expected { requested: Request, found: String },
     ExpectedTypeDeclarationKeyword,
-    ExpectedDeclarationKeyword,
     Nat32LiteralTooBig,
 }
 

--- a/ast/src/parser/mod.rs
+++ b/ast/src/parser/mod.rs
@@ -1,25 +1,28 @@
 pub mod base;
 pub mod identifier;
 pub mod show;
+pub mod lex;
 mod combinator;
 mod pattern;
 mod program;
 mod special;
 mod term;
 mod types;
-mod lex;
 
-use crate::parser:: base::{Error, Program};
+
+use crate::base::Program;
+use crate::parser:: base::Error;
 
 pub fn parse_program(s: &str) -> Result<Program, Error> {
-    Program::parse(s)
+    base::parse_program(s)
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::base::{Term, Type, FunctionDeclaration, LetDeclaration};
+    use crate::identifier::interner;
     use crate::parser::{
-        base::{State, Result, Error, Term, Type, PreTypeDeclaration, FunctionDeclaration, LetDeclaration, PreEnumDeclaration, PreIndDeclaration},
-        identifier::interner,
+        base::{State, Result, Error, PreTypeDeclaration, PreEnumDeclaration, PreIndDeclaration},
         types::type_,
         program::{pre_program, let_declaration, function_declaration, type_declaration},
     };

--- a/ast/src/parser/pattern.rs
+++ b/ast/src/parser/pattern.rs
@@ -1,8 +1,10 @@
+use crate::base::{Pattern, PatternBranch};
+use crate::identifier;
+use crate::identifier::{Variable, ConstructorName, Identifier};
 use crate::parser::lex::lexer::Request;
 use crate::parser::{
-    base::{State, Result, Error, Pattern, PatternBranch},
-    identifier,
-    identifier::{Variable, ConstructorName, Identifier, identifier, variable},
+    base::{State, Result, Error},
+    identifier::{identifier, variable},
     term::term,
     special::{comma, or_separator},
     combinator::{delimited_nonempty_sequence_to_vector, delimited_possibly_empty_sequence_to_vector},

--- a/ast/src/parser/program.rs
+++ b/ast/src/parser/program.rs
@@ -1,18 +1,19 @@
+use crate::base::{LetDeclaration, TypedFunction, Function, FunctionType, FunctionDeclaration, ConstructorDeclaration};
+use crate::identifier;
+use crate::identifier::{Variable, FunctionName};
 use crate::parser::lex::{
     token::{Token, Keyword},
     lexer::{Request, LocatedToken, DeclarationKind},
 };
 use crate::parser::{
-    base::{State, Result, Error, PreProgram, Declaration, LetDeclaration, TypedFunction, Function, FunctionType, FunctionDeclaration, PreIndDeclaration, PreEnumDeclaration, PreTypeDeclaration, ConstructorDeclaration},
-    identifier,
-    identifier::{Variable, FunctionName, variable, constructor_name, function_name},
+    base::{State, Result, Error, PreProgram, Declaration, PreIndDeclaration, PreEnumDeclaration, PreTypeDeclaration},
+    identifier::{variable, constructor_name, function_name},
     term::{term, typed_term},
     types::{type_nonempty_sequence, function_type_annotation},
     pattern::{parameter_non_empty_sequence, parameter_possibly_empty_sequence},
     special::{or_separator, do_nothing},
     combinator::delimited_possibly_empty_sequence_to_vector,
 };
-use std::collections::HashMap;
 
 pub fn pre_program(state: &mut State) -> Result<PreProgram> {
     let mut program = PreProgram::new();

--- a/ast/src/parser/show.rs
+++ b/ast/src/parser/show.rs
@@ -1,7 +1,5 @@
-use crate::parser::{
-    base::{Program, Type, FunctionType, TypeDeclaration, FunctionDeclaration, LetDeclaration, EnumDeclaration, IndDeclaration, ConstructorDeclaration},
-    identifier::{Identifier, Interner},
-};
+use crate::base::{Program, Type, FunctionType, TypeDeclaration, FunctionDeclaration, LetDeclaration, EnumDeclaration, IndDeclaration, ConstructorDeclaration};
+use crate::identifier::{Identifier, Interner};
 
 pub struct Show<'a> {
     interner: &'a Interner,

--- a/ast/src/parser/show.rs
+++ b/ast/src/parser/show.rs
@@ -15,8 +15,8 @@ impl <'show>Show<'show> {
     }
 
     pub fn show_program_declarations(&self, program: &Program) -> String {
-        let type_declarations = program.type_declarations.values().map(|decl| self.show_type_declaration(decl)).collect::<Vec<_>>().join("\n\n");
-        let function_declarations = program.function_declarations.values().map(|decl| self.show_function_declaration(decl)).collect::<Vec<_>>().join("\n");
+        let type_declarations =  program.type_declarations_in_source_ordering().iter().map(|decl| self.show_type_declaration(decl)).collect::<Vec<_>>().join("\n\n");
+        let function_declarations = program.function_declarations_in_source_ordering().iter().map(|decl| self.show_function_declaration(decl)).collect::<Vec<_>>().join("\n");
         let let_declarations = program.let_declarations.values().map(|decl| self.show_let_declaration(decl)).collect::<Vec<_>>().join("\n");
         format!("{type_declarations}\n\n{function_declarations}\n{let_declarations}")
     }
@@ -31,7 +31,7 @@ impl <'show>Show<'show> {
 
     fn show_enum_declaration(&self, declaration: &EnumDeclaration) -> String {
         let name_str = declaration.name.str(self.interner());
-        let constructor_strs = declaration.constructors.values().map(|cons| self.show_constructor_declaration(cons)).collect::<Vec<_>>().join("\n");
+        let constructor_strs = declaration.constructors_in_source_ordering().iter().map(|decl| self.show_constructor_declaration(decl)).collect::<Vec<_>>().join("\n");
         let after_equals_str = format!("enum {{\n{constructor_strs}\n}}");
         if declaration.type_parameters.is_empty() {
             format!("type {name_str} = {after_equals_str}")
@@ -44,7 +44,7 @@ impl <'show>Show<'show> {
     fn show_ind_declaration(&self, declaration: &IndDeclaration) -> String {
         let name_str = declaration.name.str(self.interner());
         let rec_var_str = declaration.recursive_type_var.str(self.interner());
-        let constructor_strs = declaration.constructors.values().map(|cons| self.show_constructor_declaration(cons)).collect::<Vec<_>>().join("\n");
+        let constructor_strs = declaration.constructors_in_source_ordering().iter().map(|decl| self.show_constructor_declaration(decl)).collect::<Vec<_>>().join("\n");
         let after_equals_str = format!("ind {{ {rec_var_str} .\n{constructor_strs}\n}}");
         if declaration.type_parameters.is_empty() {
             format!("type {name_str} = {after_equals_str}")

--- a/ast/src/parser/special.rs
+++ b/ast/src/parser/special.rs
@@ -1,10 +1,11 @@
+use crate::identifier::{Variable, ConstructorName};
 use crate::parser::lex::{
     token::SeparatorSymbol,
     lexer::{Position, Request, LocatedToken},
 };
 use crate::parser::{
     base::{State, Result, Error},
-    identifier::{Variable, ConstructorName, identifier},
+    identifier::identifier,
 };
 
 pub fn comma(state: &mut State) -> Result<Position> {
@@ -14,11 +15,6 @@ pub fn comma(state: &mut State) -> Result<Position> {
 
 pub fn or_separator(state: &mut State) -> Result<Position> {
     let LocatedToken { position, .. } = state.request_token(Request::Separator(SeparatorSymbol::Or))?;
-    Ok(position)
-}
-
-pub fn and_separator(state: &mut State) -> Result<Position> {
-    let LocatedToken { position, .. } = state.request_token(Request::Separator(SeparatorSymbol::And))?;
     Ok(position)
 }
 

--- a/ast/src/parser/term.rs
+++ b/ast/src/parser/term.rs
@@ -1,10 +1,12 @@
+use crate::base::{Term, TypedTerm, Type};
+use crate::identifier::Variable;
 use crate::parser::lex::{
     token::Keyword,
     lexer::Request,
 };
 use crate::parser::{
-    base::{State, Result, Term, TypedTerm, Type},
-    identifier::{Variable, variable},
+    base::{State, Result},
+    identifier::variable,
     types::{type_annotation, type_nonempty_sequence},
     pattern::pattern_branches,
     program::function,

--- a/ast/src/parser/types.rs
+++ b/ast/src/parser/types.rs
@@ -1,9 +1,10 @@
+use crate::base::{FunctionType, Type};
 use crate::parser::lex::{
     token::Keyword,
     lexer::Request,
 };
 use crate::parser::{
-    base::{State, Result, FunctionType, Type},
+    base::{State, Result},
     special::{VariableOrConstructorName, comma, constructor_name_or_variable},
     combinator::{delimited_nonempty_sequence_to_vector, delimited_possibly_empty_sequence_to_vector},
 };

--- a/ast/src/validation/base.rs
+++ b/ast/src/validation/base.rs
@@ -1,8 +1,6 @@
-use crate::parser::{
-    identifier::{Variable, ConstructorName, FunctionName, Interner},
-    base::Type,
-    show::Show,
-};
+use crate::base::Type;
+use crate::identifier::{Variable, ConstructorName, FunctionName};
+use crate::parser::show::Show;
 
 pub type Result<A> = std::result::Result<A, Error>;
 

--- a/ast/src/validation/term_formation.rs
+++ b/ast/src/validation/term_formation.rs
@@ -150,11 +150,12 @@ fn type_infer(env: &mut Environment, term: &Term) -> Result<Type> {
             let Some((constructor_decl, specialized_types)) = type_decl.type_apply_constructor(constructor_name, &vec![]) else { unreachable!() };
             if constructor_decl.arity() != args.len() { return Err(Error::ConstructorIsAppliedToWrongNumberOfArguments { constructor_name: constructor_name.clone(), expected: constructor_decl.arity(), received: args.len() }) }
 
+            let type_name = type_decl.name().clone();
             for (arg, type_) in args.iter().zip(&specialized_types) { 
                 type_check(env, arg, &type_)?
             }
 
-            Ok(Type::TypeApplication(constructor_name.clone(), vec![]))
+            Ok(Type::TypeApplication(type_name, vec![]))
         },
         Lambda(_function) => {
             Err(Error::UnableToInferTypeOfLambda)

--- a/ast/src/validation/term_formation.rs
+++ b/ast/src/validation/term_formation.rs
@@ -65,7 +65,7 @@ impl <'env>Environment<'env> {
     }
 
     pub fn get_type(&self, var: &Variable) -> Option<&Type> {
-        for bindings in &self.bindings_stack {
+        for bindings in self.bindings_stack.iter().rev() {
             match bindings.get(var) {
                 Some(type_) => return Some(type_),
                 None => {},

--- a/ast/src/validation/term_formation.rs
+++ b/ast/src/validation/term_formation.rs
@@ -1,7 +1,5 @@
-use crate::parser::{
-    identifier::{Variable, FunctionName, ConstructorName},
-    base::{Program, TypeDeclaration, Type, FunctionType, ConstructorDeclaration, FunctionDeclaration, LetDeclaration, Term, Pattern, PatternBranch },
-};
+use crate::base::{Program, TypeDeclaration, Type, FunctionDeclaration, LetDeclaration, Term, Pattern, PatternBranch};
+use crate::identifier::{Variable, FunctionName, ConstructorName};
 use crate::validation:: {
     base::{Result, Error, ErrorWithLocation},
     type_formation,
@@ -127,55 +125,6 @@ impl <'env>Environment<'env> {
 fn eq_type(type0: &Type, type1: &Type) -> bool {
     // TODO: Is this really enough?
     type0 == type1
-}
-
-// We are expecting the `term` to be of Arrow type.
-fn type_infer_arrow_inputs(env: &mut Environment, term: &Term, expected_out_type: &Type) -> Result<Vec<Type>> {
-    use Term::*;
-    match term {
-        TypedTerm(typed_term) => {
-            // TODO: You need to check that the type of the type annotation is well-formed.
-            //let type_ = &typed_term.type_;
-            //let term = &typed_term.term;
-            //
-            //let Type::Arrow(fn_type) = type_ else { return Err(Error::TermDoesntHaveExpectedArrowType { received: type_.clone() }) };
-            //type_check(env, term, type_)?;
-            //
-            //eq_type(fn_type.output_type)
-            //
-            //Ok(fn_type.input_types.clone())
-            todo!()
-        },
-        VariableUse(var) => {
-            match env.get_type(var) {
-                Some(type_) => todo!(),
-                None => Err(Error::VariableOutOfScope { variable: var.clone() }),
-            }
-        },
-        Lambda(function) => {
-            todo!()
-        },
-        FunctionApplication(fn_name, type_args, args) => {
-            // type infer args, then feed them into fn_name
-            todo!()
-        },
-        Match(arg, branches) => {
-            todo!()
-        },
-        Fold(arg, branches) => {
-            todo!()
-        },
-        LambdaApplication(fn_term, args) => {
-            todo!()
-        },
-        Let(bindings, body) => {
-            todo!()
-        },
-        ConstructorUse(_, _) => {
-            // TODO: Error: Can't possibly be of Arrow type
-            todo!()
-        }
-    }
 }
 
 fn type_infer(env: &mut Environment, term: &Term) -> Result<Type> {

--- a/ast/src/validation/type_formation.rs
+++ b/ast/src/validation/type_formation.rs
@@ -1,7 +1,5 @@
-use crate::parser::{
-    identifier::Variable,
-    base::{Program, TypeDeclaration, Type, FunctionType, ConstructorDeclaration, FunctionDeclaration, LetDeclaration, Term, Pattern, PatternBranch },
-};
+use crate::base::{Program, TypeDeclaration, Type, FunctionType, ConstructorDeclaration, FunctionDeclaration, LetDeclaration};
+use crate::identifier::Variable;
 use crate::validation:: base::{Result, Error, ErrorWithLocation};
 use std::collections::HashSet;
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 wasm = { path = "../wasm" }
+ast = { path = "../ast" }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 wasm = { path = "../wasm" }
 ast = { path = "../ast" }
+clap = "4.5.9"

--- a/compiler/src/graph_memory_machine.rs
+++ b/compiler/src/graph_memory_machine.rs
@@ -12,6 +12,9 @@ pub enum Term {
     Tuple(Variant, Vec<Term>),
     ProjectComponent(Box<Term>, ComponentIndex),
     Call(FunctionName, Vec<Term>),
+    // This is used to created closures.
+    // Note that even though the arguments are in general variables, some of these arguments
+    // can be projections of variables.
     PartialApply(FunctionName, Vec<Term>),
     CallClosure(Box<Term>, Vec<Term>),
     VarUse(VarName),

--- a/compiler/src/graph_memory_machine.rs
+++ b/compiler/src/graph_memory_machine.rs
@@ -1,4 +1,3 @@
-
 pub type Variant = i32;
 
 pub type FunctionName = usize;
@@ -9,6 +8,7 @@ pub type ComponentIndex = u8; // max 256 components
 pub enum Term {
     Const(Variant),
     ByteArray(Vec<u8>),
+    // TODO: Rename to Cons (Constructor)
     Tuple(Variant, Vec<Term>),
     ProjectComponent(Box<Term>, ComponentIndex),
     Call(FunctionName, Vec<Term>),

--- a/compiler/src/graph_memory_machine.rs
+++ b/compiler/src/graph_memory_machine.rs
@@ -16,6 +16,8 @@ pub enum Term {
     CallClosure(Box<Term>, Vec<Term>),
     VarUse(VarName),
     Let(Vec<Term>, Box<Term>), // let x0 = e0, x1 = e1, ... in body
+    // Intention behind match is that the argument will be bound to a new variable
+    // that will be accessible in the bodies.
     Match(Box<Term>, Vec<(Pattern, Term)>),
     Seq(Vec<Term>),
 }

--- a/compiler/src/main.rs
+++ b/compiler/src/main.rs
@@ -1,31 +1,152 @@
-use std::io;
-use std::io::Write;
-use std::fs;
-
 mod graph_memory_machine;
 mod interpreter;
 mod polymede_compiler;
+mod show;
 
+use std::io;
+use std::io::Write;
+use std::fs;
+use clap::Parser;
 use wasm;
+use ast::parser;
 
 type Result<A> = std::result::Result<A, io::Error>;
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    #[arg(short, long)]
+    file: String,
+}
+
+fn check_program(program: &ast::base::Program) -> core::result::Result<(), Vec<ast::validation::base::ErrorWithLocation>> {
+    ast::validation::type_formation::check_program(&program)?;
+    ast::validation::term_formation::check_program(&program)?;
+    Ok(())
+}
 
 fn main() -> Result<()> {
     // let bytes = wasm::generate0();
     // let bytes = wasm::generate1();
     // let bytes = wasm::generate_factorial();
     // let bytes = wasm::generate_memory0();
-    let bytes = wasm::generate_memory1();
+    //let bytes = wasm::generate_memory1();
 
-    let mut file = fs::OpenOptions::new()
-        .create(true) // To create a new file
-        .write(true)
-        // either use the ? operator or unwrap since it returns a Result
-        .open("./tmp_wasm/test.wasm")?;
-
-    file.write_all(&bytes)?;
-
-    println!("{bytes:?}");
+    //let mut file = fs::OpenOptions::new()
+    //    .create(true) // To create a new file
+    //    .write(true)
+    //    // either use the ? operator or unwrap since it returns a Result
+    //    .open("./tmp_wasm/test.wasm")?;
+    //
+    //file.write_all(&bytes)?;
+    //
+    //println!("{bytes:?}");
     
+
+    let args = Args::parse();
+    let str = fs::read_to_string(args.file)?;
+    match parser::parse_program(&str) {
+        Ok(program) => {
+            let sh = parser::show::Show::new(&program.interner());
+            println!("===Signature .pmd===");
+            println!("{}", sh.show_program_declarations(&program));
+
+            match check_program(&program) {
+                Ok(()) => {
+                    let gmm_program = polymede_compiler::compile(0, &program);
+                    let s = show::show_program(&gmm_program).str();
+                    println!("");
+                    println!("");
+                    println!("===Compiled .gmm===");
+                    println!("{}", s);
+                },
+                Err(errors) => {
+                    println!("===TYPE ERROR===");
+                    for e in errors {
+                        println!("{}\n", e.show(&sh))
+                    }
+                }
+            }
+        },
+        Err(err) => {
+            println!("====PARSING ERROR===");
+            println!("{:?}", err);
+        },
+    }
+    // TODO
+    //example0();
+
     Ok(())
+}
+
+fn example0() {
+    use graph_memory_machine::*;
+
+    let program = {
+        let add = 0;
+        let another_add = 1;
+        Program {
+            // Assume the first primitive function is `inc`.
+            number_of_primitive_functions: 1,
+            functions: vec![
+                // fn another_add(self, x, y) {
+                //     x + y
+                // }
+                Function {
+                    number_of_parameters: 3,
+                    body: {
+                        // let self_var = 0;
+                        let x = 1;
+                        let y = 2;
+                        call(add, vec![var(x), var(y)])
+                    }
+                }
+            ],
+            main: call_closure(partial_apply(another_add, vec![constant(5)]), vec![constant(6)]),
+        }
+    };
+
+    println!("is this exec?");
+    let term = {
+        let add = 0;
+        let x = 1;
+        let y = 2;
+        //call(add, vec![var(x), var(y), call(add, vec![var(x)]), var(x)])
+        //project(tuple(0, vec![constant(64), var(y), byte_array(vec![2, 5, 6, 1])]), 1)
+        //let_bind(vec![var(x), var(y)], var(4))
+        //pattern_match(
+        //    tuple(0, vec![]),
+        //    vec![(Pattern::Variant(0), var(x)), (Pattern::Variant(1), var(y))]
+        //)
+        //pattern_match(
+        //    tuple(1, vec![var(x)]),
+        //    vec![(Pattern::Variant(0), var(x)), (Pattern::Variant(1), var(y))]
+        //)
+        tuple(5, vec![
+            pattern_match(
+                tuple(1, vec![var(x)]),
+                vec![(Pattern::Variant(0), var(x)), (Pattern::Variant(1), var(y))]
+            )
+        ])
+    };
+
+
+    let function = {
+        let add = 0;
+        Function {
+            number_of_parameters: 3,
+            body: {
+                // let self_var = 0;
+                let x = 1;
+                let y = 2;
+                call(add, vec![var(x), var(y)])
+            }
+        }
+    };
+
+    use show::{show_term, show_function, show_program};
+    //let s = show_term(&term, 3).str();
+    //let s = show_function(&function, 54).str();
+    let s = show_program(&program).str();
+    println!("{}", s);
 }

--- a/compiler/src/main.rs
+++ b/compiler/src/main.rs
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
 
             match check_program(&program) {
                 Ok(()) => {
-                    let gmm_program = polymede_compiler::compile(0, &program);
+                    let gmm_program = polymede_compiler::compile(250, &program);
                     let s = show::show_program(&gmm_program).str();
                     println!("");
                     println!("");

--- a/compiler/src/main.rs
+++ b/compiler/src/main.rs
@@ -4,9 +4,9 @@ use std::fs;
 
 mod graph_memory_machine;
 mod interpreter;
+mod polymede_compiler;
 
 use wasm;
-
 
 type Result<A> = std::result::Result<A, io::Error>;
 

--- a/compiler/src/polymede_compiler.rs
+++ b/compiler/src/polymede_compiler.rs
@@ -1,0 +1,195 @@
+use ast::base as polymede;
+use ast::identifier::{FunctionName, ConstructorName, Variable};
+use crate::graph_memory_machine as gmm;
+
+use std::collections::HashMap;
+
+type FunctionIndex = usize;
+type VariableIndex = usize;
+type ConstructorIndex = i32;
+
+struct State {
+    number_of_primitive_functions: usize,
+
+    function_count: FunctionIndex,
+    function_mapping: HashMap<FunctionName, FunctionIndex>,
+    functions: Vec<gmm::Function>,
+    constructor_mapping: HashMap<ConstructorName, ConstructorIndex>,
+    env: Vec<Scope>,
+}
+
+struct Scope {
+    count: VariableIndex,
+    mapping: HashMap<Variable, VariableIndex>,
+}
+
+impl State {
+    pub fn new(number_of_primitive_functions: usize) -> Self {
+        Self {
+            number_of_primitive_functions,
+
+            function_count: 0,
+            function_mapping: HashMap::new(),
+            functions: vec![],
+            constructor_mapping: HashMap::new(),
+            env: vec![Scope::new()],
+        }
+    }
+
+    fn get_constructor_index(&self, constructor_name: &ConstructorName) -> Option<ConstructorIndex> {
+        self.constructor_mapping.get(constructor_name).copied()
+    }
+
+    fn get_function_index(&self, function_name: &FunctionName) -> Option<FunctionIndex> {
+        self.function_mapping.get(function_name).copied()
+    }
+
+    fn add_function_name(&mut self, function_name: FunctionName) {
+        self.function_mapping.insert(function_name, self.function_count);
+        self.function_count += 1;
+    }
+
+    fn open_env(&mut self) {
+        self.env.push(Scope::new())
+    }
+
+    fn close_env(&mut self) {
+        let _ = self.env.pop();
+    }
+
+    fn extend_var(&mut self, var: Variable) {
+        match self.env.last_mut() {
+            Some(scope) => {
+                scope.extend_var(var)
+            },
+            None => unreachable!(),
+        }
+    }
+
+    fn extend_vars(&mut self, vars: Vec<Variable>) {
+        match self.env.last_mut() {
+            Some(scope) => {
+                scope.extend_vars(vars)
+            },
+            None => unreachable!(),
+        }
+    }
+    
+    fn get_var(&self, var: &Variable) -> Option<VariableIndex> {
+        for scope in self.env.iter().rev() {
+            match scope.get(var) {
+                Some(var_index) => return Some(var_index),
+                None => {},
+            }
+        }
+        None
+    }
+}
+
+impl Scope {
+    fn new() -> Self {
+        Self { count: 0, mapping: HashMap::new() }
+    }
+
+    fn extend_var(&mut self, var: Variable) {
+        self.mapping.insert(var, self.count);
+        self.count += 1;
+    }
+
+    fn extend_vars(&mut self, vars: Vec<Variable>) {
+        for var in vars {
+            self.extend_var(var)
+        }
+    }
+
+    fn get(&self, var: &Variable) -> Option<VariableIndex> {
+        self.mapping.get(var).copied()
+    }
+}
+
+fn compile(mut state: State, program: &polymede::Program) -> gmm::Program {
+    // ===constructors===
+    for decl in program.type_declarations.values() {
+        let mut count: ConstructorIndex = 0;
+
+        for constructor in decl.constructors().values() {
+            state.constructor_mapping.insert(constructor.name.clone(), count);
+            count += 1;
+        }
+    }
+
+    // ===functions===
+    for decl in program.function_declarations.values() { 
+        state.add_function_name(decl.name())
+    }
+
+    // TODO: This vector shuffling is way too complicated.
+    let mut functions: Vec<(FunctionIndex, gmm::Function)> = vec![];
+    for decl in program.function_declarations.values() { 
+        let Some(fn_index) = state.get_function_index(&decl.name()) else { unreachable!() };
+        functions.push((fn_index, compile_function_declaration(&mut state, &decl.function.function)));
+    }
+    functions.sort_by(|(i, _), (j, _)| i.partial_cmp(j).unwrap());
+
+    for (_, function) in functions {
+        state.functions.push(function)
+    }
+
+    gmm::Program {
+        number_of_primitive_functions: state.number_of_primitive_functions,
+        functions: state.functions,
+        main: gmm::constant(0), // TODO
+    }
+}
+
+fn compile_function_declaration(state: &mut State, function: &polymede::Function) -> gmm::Function {
+    state.extend_vars(function.parameters.clone());
+    gmm::Function {
+        number_of_parameters: function.parameters.len(),
+        body: compile_term(state, &function.body),
+    }
+}
+
+fn compile_term(state: &mut State, term: &polymede::Term) -> gmm::Term {
+    use polymede::Term::*;
+    match term {
+        TypedTerm(typed_term) => compile_term(state, &typed_term.term),
+        VariableUse(var) => {
+            let Some(var_index) = state.get_var(var) else { unreachable!() };
+            gmm::Term::VarUse(var_index)
+        },
+        FunctionApplication(function_name, _, args) => {
+            let Some(fn_index) = state.get_function_index(function_name) else { unreachable!() };
+            gmm::Term::Call(fn_index, args.iter().map(|arg| compile_term(state, arg)).collect())
+        },
+        ConstructorUse(constructor_name, args) => {
+            let Some(constructor_index) = state.get_constructor_index(constructor_name) else { unreachable!() };
+            gmm::Term::Tuple(constructor_index, args.iter().map(|arg| compile_term(state, arg)).collect())
+        },
+        Match(term, pattern_branch) => {
+            todo!()
+        },
+        Fold(term, pattern_branch) => {
+            todo!()
+        },
+        Lambda(function) => {
+            todo!()
+        },
+        LambdaApplication(fn_term, args) => {
+            todo!()
+        },
+        Let(bindings, body) => {
+            state.open_env();
+            let mut vars: Vec<Variable> = Vec::with_capacity(bindings.len());
+            let mut gmm_args: Vec<gmm::Term> = Vec::with_capacity(bindings.len());
+            for (var, term) in bindings {
+                vars.push(var.clone());
+                state.extend_var(var.clone());
+                gmm_args.push(compile_term(state, term))
+            }
+            let gmm_body = compile_term(state, body);
+            state.close_env();
+            gmm::Term::Let(gmm_args, Box::new(gmm_body))
+        },
+    }
+}

--- a/compiler/src/polymede_compiler.rs
+++ b/compiler/src/polymede_compiler.rs
@@ -110,23 +110,23 @@ impl Scope {
 pub fn compile(number_of_primitive_functions: usize, program: &polymede::Program) -> gmm::Program {
     let mut state = State::new(number_of_primitive_functions);
     // ===constructors===
-    for decl in program.type_declarations.values() {
+    for decl in program.type_declarations_in_source_ordering() {
         let mut count: ConstructorIndex = 0;
 
-        for constructor in decl.constructors().values() {
+        for constructor in decl.constructors_in_source_ordering() {
             state.constructor_mapping.insert(constructor.name.clone(), count);
             count += 1;
         }
     }
 
     // ===functions===
-    for decl in program.function_declarations.values() { 
+    for decl in program.function_declarations_in_source_ordering() { 
         state.add_function_name(decl.name())
     }
 
     // TODO: This vector shuffling is way too complicated.
     let mut functions: Vec<(FunctionIndex, gmm::Function)> = vec![];
-    for decl in program.function_declarations.values() { 
+    for decl in program.function_declarations_in_source_ordering() { 
         let Some(fn_index) = state.get_function_index(&decl.name()) else { unreachable!() };
         functions.push((fn_index, compile_function_declaration(&mut state, &decl.function.function)));
     }

--- a/compiler/src/polymede_compiler.rs
+++ b/compiler/src/polymede_compiler.rs
@@ -107,7 +107,8 @@ impl Scope {
     }
 }
 
-fn compile(mut state: State, program: &polymede::Program) -> gmm::Program {
+pub fn compile(number_of_primitive_functions: usize, program: &polymede::Program) -> gmm::Program {
+    let mut state = State::new(number_of_primitive_functions);
     // ===constructors===
     for decl in program.type_declarations.values() {
         let mut count: ConstructorIndex = 0;
@@ -166,10 +167,10 @@ fn compile_term(state: &mut State, term: &polymede::Term) -> gmm::Term {
             let Some(constructor_index) = state.get_constructor_index(constructor_name) else { unreachable!() };
             gmm::Term::Tuple(constructor_index, args.iter().map(|arg| compile_term(state, arg)).collect())
         },
-        Match(term, pattern_branch) => {
+        Match(arg, pattern_branch) => {
             todo!()
         },
-        Fold(term, pattern_branch) => {
+        Fold(arg, pattern_branch) => {
             todo!()
         },
         Lambda(function) => {

--- a/compiler/src/show.rs
+++ b/compiler/src/show.rs
@@ -157,17 +157,18 @@ pub fn show_term(term: &Term, next_parameter: usize) -> PrettyString {
             string(format!("${}", var))
         },
         Let(args, body) => {
-            let mut strs = vec![];
+            let mut strs = vec![str("{")];
             let mut count = next_parameter;
             for arg in args {
                 strs.push(seq(vec![
                         string(format!("let {} = ", count)),
                         ignore_indentation(show_term(arg, count + 1)),
-                        str(";"),
+                        str("; "),
                 ]));
                 count += 1;
             }
             strs.push(show_term(body, count));
+            strs.push(str("}"));
             lines(strs)
         },
         Match(arg, branches) => {

--- a/compiler/src/show.rs
+++ b/compiler/src/show.rs
@@ -1,0 +1,194 @@
+use crate::graph_memory_machine::{Program, Function, Term, Pattern};
+
+pub enum PrettyString {
+    String(String),
+    Sequence(Vec<PrettyString>, Separator),
+    Indent(Box<PrettyString>),
+    Lines(Vec<PrettyString>, Separator),
+    IgnoreNewLines(Box<PrettyString>),
+}
+
+pub enum Separator {
+    None,
+    Comma,
+    Or,
+}
+
+impl Separator {
+    fn str(&self) -> &str {
+        match self {
+            Separator::None => "",
+            Separator::Comma => ", ",
+            Separator::Or => " | "
+        }
+    }
+}
+
+impl PrettyString {
+    pub fn str(self) -> String {
+        fn show(s: PrettyString, indentation: usize, ignore_new_lines: bool) -> String {
+            let indent_by: usize = 2;
+
+            use PrettyString::*;
+            match s {
+                String(s) => {
+                    if ignore_new_lines {
+                        s
+                    } else {
+                        let ws = " ".repeat(indentation);
+                        format!("{}{}", ws, s)
+                    }
+                },
+                Sequence(ss, sep) => {
+                    ss.into_iter().map(|s| show(s, indentation, ignore_new_lines)).collect::<Vec<_>>().join(sep.str())
+                },
+                Indent(s) => show(*s, indentation + indent_by, ignore_new_lines),
+                Lines(ss, sep) => {
+                    if ignore_new_lines {
+                        ss.into_iter().map(|s| show(s, indentation, ignore_new_lines)).collect::<Vec<_>>().join(sep.str())
+                    } else {
+                        ss.into_iter().map(|s| show(s, indentation, ignore_new_lines)).collect::<Vec<_>>().join(&format!("{}\n", sep.str()))
+                    }
+                },
+                IgnoreNewLines(s) => show(*s, indentation, true),
+            }
+        }
+
+        show(self, 0, false)
+    }
+}
+
+fn str(s: &str) -> PrettyString {
+    PrettyString::String(s.to_string())
+}
+
+fn string(s: String) -> PrettyString {
+    PrettyString::String(s)
+}
+
+fn seq(ss: Vec<PrettyString>) -> PrettyString {
+    PrettyString::Sequence(ss, Separator::None)
+}
+
+fn comma_seq(ss: Vec<PrettyString>) -> PrettyString {
+    PrettyString::Sequence(ss, Separator::Comma)
+}
+
+fn indent(s: PrettyString) -> PrettyString {
+    PrettyString::Indent(Box::new(s))
+}
+
+fn lines(ss: Vec<PrettyString>) -> PrettyString {
+    PrettyString::Lines(ss, Separator::None)
+}
+
+fn or_lines(ss: Vec<PrettyString>) -> PrettyString {
+    PrettyString::Lines(ss, Separator::Or)
+}
+
+fn ignore_indentation(s: PrettyString) -> PrettyString {
+    PrettyString::IgnoreNewLines(Box::new(s))
+}
+
+pub fn show_program(program: &Program) -> PrettyString {
+    let mut ss = vec![];
+    for (i, function) in program.functions.iter().enumerate() {
+        ss.push(show_function(function, i + program.number_of_primitive_functions))
+    }
+    lines(ss)
+}
+
+pub fn show_function(function: &Function, function_index: usize) -> PrettyString {
+    let parameters: Vec<_> = (0..function.number_of_parameters).map(|i| string(format!("{}", i))).collect();
+    lines(vec![
+        seq(vec![str("fn "), string(format!("{}", function_index)), str("("), comma_seq(parameters), str(") {")]),
+        indent(show_term(&function.body, function.number_of_parameters)),
+        str("}"),
+    ])
+}
+
+pub fn show_term(term: &Term, next_parameter: usize) -> PrettyString {
+    use Term::*;
+
+    match term {
+        Const(variant) => string(format!("{}", variant)),
+        ByteArray(bytes) => string(format!("[{}]", bytes.iter().map(|byte| format!("{}", byte)).collect::<Vec<_>>().join(", "))),
+        Tuple(variant, args) => {
+            if args.is_empty() {
+                string(format!("Cons(@{})", variant))
+            } else {
+                seq(vec![
+                    string(format!("Cons(@{}; ", variant)),
+                    ignore_indentation(comma_seq(args.iter().map(|arg| show_term(arg, next_parameter)).collect())),
+                    str(")"),
+                ])
+            }
+        },
+        ProjectComponent(term, index) => {
+            seq(vec![
+                str("Pi("),
+                ignore_indentation(show_term(term, next_parameter)),
+                string(format!(", {})", index)),
+            ])
+        },
+        Call(function_name, args) => {
+            seq(vec![
+                string(format!("call {}(", function_name)),
+                ignore_indentation(comma_seq(args.iter().map(|arg| show_term(arg, next_parameter)).collect())),
+                str(")"),
+            ])
+        },
+        PartialApply(function_name, args) => {
+            seq(vec![
+                string(format!("papply {}(", function_name)),
+                ignore_indentation(comma_seq(args.iter().map(|arg| show_term(arg, next_parameter)).collect())),
+                str(")"),
+            ])
+        },
+        CallClosure(term, args) => {
+            seq(vec![
+                str("call-closure {}("),
+                ignore_indentation(show_term(term, next_parameter)),
+                ignore_indentation(comma_seq(args.iter().map(|arg| show_term(arg, next_parameter)).collect())),
+                str(")"),
+            ])
+        },
+        VarUse(var) => {
+            string(format!("${}", var))
+        },
+        Let(args, body) => {
+            let mut strs = vec![];
+            let mut count = next_parameter;
+            for arg in args {
+                strs.push(seq(vec![
+                        string(format!("let {} = ", count)),
+                        ignore_indentation(show_term(arg, count + 1)),
+                        str(";"),
+                ]));
+                count += 1;
+            }
+            strs.push(show_term(body, count));
+            lines(strs)
+        },
+        Match(arg, branches) => {
+            lines(vec![
+                seq(vec![ str("match "), show_term(arg, next_parameter), str(" {") ]),
+                or_lines({
+                    let mut branches_s = vec![];
+                    for (pattern, body) in branches {
+                        let pattern_s = match pattern {
+                            Pattern::Variant(variant) => string(format!("@{}", variant)),
+                            Pattern::Always => str("_"),
+                        };
+                        branches_s.push(ignore_indentation(seq(vec![pattern_s, str(" . "), show_term(body, next_parameter + 1)])))
+                    }
+                    branches_s
+                }),
+                str("}")
+            ])
+        },
+        Seq(terms) => {
+            todo!()
+        },
+    }
+}

--- a/compiler/src/show.rs
+++ b/compiler/src/show.rs
@@ -147,8 +147,9 @@ pub fn show_term(term: &Term, next_parameter: usize) -> PrettyString {
         },
         CallClosure(term, args) => {
             seq(vec![
-                str("call-closure {}("),
+                str("call-closure "),
                 ignore_indentation(show_term(term, next_parameter)),
+                str("("),
                 ignore_indentation(comma_seq(args.iter().map(|arg| show_term(arg, next_parameter)).collect())),
                 str(")"),
             ])

--- a/examples/010_lambda.pmd
+++ b/examples/010_lambda.pmd
@@ -27,6 +27,7 @@ fn showing_application = forall { a, b . # Fn(a -> b), a -> b { f, a .
   apply f to (a)
 }}
 
+// Consider instead of `apply f to (a1, a2)` to have atleast `[f (a1, a2)]`  or even... `$f(a1, a2)`
 
 // So basically `fn` is an operator, that takes in a judgment 
 //     # Int -> Int { x . x * x }

--- a/examples/closure_test.pmd
+++ b/examples/closure_test.pmd
@@ -1,0 +1,33 @@
+
+type Bool = enum {
+| T
+| F
+}
+
+type Pair(a, b) = enum {
+| Pair(a, b)
+}
+
+fn f = # Bool, Bool -> Fn(Bool, Bool -> Pair(Bool, Pair(Bool, Fn(Bool -> Bool)))) : { x, y . 
+  let {
+  , free = T
+  . fn { z, w .
+      let {
+      , g = # Fn(Bool -> Bool) : fn { u . free }
+      , h = # Fn(Bool -> Bool) : fn { u .
+          match u {
+          | T . apply g to (F)
+          | F . T
+          }
+        }
+      , first = # Fn(Pair(Bool, Bool) -> Bool) : fn { pair .
+          match pair {
+          | Pair(a, b) . a
+          }
+        }
+      . Pair(apply first to(Pair(x, x)), Pair(y, g))
+      }
+    } 
+  }
+}
+

--- a/examples/simple_test.pmd
+++ b/examples/simple_test.pmd
@@ -1,0 +1,55 @@
+
+type Bool = enum {
+| T
+| F
+}
+
+type Pair(a, b) = enum {
+| Pair(a, b)
+}
+
+fn id_bool = # Bool -> Bool : { x . x }
+
+fn const_true = # -> Bool : { . T }
+fn const_false = # -> Bool : { . F }
+
+fn const_true_pair = # -> Pair(Bool, Bool) : { . Pair(T, T) }
+
+fn const_pair = # Bool -> Pair(Bool, Bool) : { x . Pair(x, x) }
+
+fn const_pair_polymorphic = forall { a . # a -> Pair(a, a) : { x . Pair(x, x) }}
+fn const_pair1 = # Bool -> Pair(Bool, Bool) : { x . Pair(x, x) }
+fn const_pair2 = # Bool -> Pair(Bool, Bool) : { x . Pair(x, x) }
+
+fn first = forall { a, b . # a, b -> a : { x, y . x } }
+fn second = forall { a, b . # a, b -> b : { x, y . y } }
+fn third = forall { a, b, c . # a, b, c -> c : { x, y, z . z } }
+
+fn call_fn_0 = # Bool -> Bool : { x . id_bool(const_false()) }
+
+fn call_fn_1 = # Bool -> Bool : { x . second<Bool, Bool>(x, id_bool(x)) }
+
+fn let_binding_0 = # Bool, Bool, Bool -> Pair(Bool, Bool) : { x, y, z .
+  let {
+  , y = # Pair(Bool, Bool) : Pair(T, F)
+  . y
+  }
+}
+
+fn let_binding_1 = # Bool, Bool, Bool -> Pair(Bool, Bool) : { x, y, z .
+  let {
+  , y0 = # Pair(Bool, Bool) : Pair(T, F)
+  , w = T
+  , z = let {
+    , u = T
+    . u
+    }
+  , u = F
+  , v = let {
+    , x = z
+    , t = x
+    . first<Bool, Bool>(x, y)
+    }
+  . y0
+  }
+}

--- a/examples/simple_test.pmd
+++ b/examples/simple_test.pmd
@@ -1,4 +1,5 @@
 
+
 type Bool = enum {
 | T
 | F

--- a/examples/simple_test.pmd
+++ b/examples/simple_test.pmd
@@ -53,3 +53,29 @@ fn let_binding_1 = # Bool, Bool, Bool -> Pair(Bool, Bool) : { x, y, z .
   . y0
   }
 }
+
+fn not = # Bool -> Bool : { x .
+  match x {
+  | T . F
+  | F . T
+  }
+}
+
+fn id_bool_another = # Bool -> Bool : { x .
+  match x {
+  | T . x
+  | y . y
+  }
+}
+
+fn p_first = # Pair(Bool, Bool) -> Bool : { p .
+  match p {
+  | Pair(x, y) . x
+  }
+}
+
+fn p_second = # Pair(Bool, Bool) -> Bool : { p .
+  match p {
+  | Pair(x, y) . y
+  }
+}

--- a/examples/simple_two.pmd
+++ b/examples/simple_two.pmd
@@ -42,7 +42,21 @@ fn test_let = # Nat -> Nat : { x .
   let {
   , y = mul(x, x)
   , z = # Fn(Nat -> Nat) : fn { x . x }
+  , w = mul(y, x) // note that here we refer to `y` which was defined previously
   . y
+  }
+}
+
+fn test_let1 = # Nat -> Nat : { x .
+  let {
+  , y = mul(x, x)
+  . let {
+    , z = # Fn(Nat -> Nat) : fn { x . x }
+    . let {
+      , w = mul(y, x)
+      . y
+      }
+    }
   }
 }
 

--- a/tmp_repl.txt
+++ b/tmp_repl.txt
@@ -75,6 +75,9 @@ cat $TMP_WAT/another_test_decompile.wat
 
 cargo test -p compiler
 
+cargo run --bin compiler
+
+cargo run --bin compiler -- -f examples/simple_test.pmd
 
 # ===WASM Runtime Support===
 

--- a/tmp_repl.txt
+++ b/tmp_repl.txt
@@ -14,7 +14,6 @@ cargo run --bin ast -- -f examples/simple_two.pmd
 
 cargo test -p ast
 
-
 # ===Expressions===
 
 rm $TMP_WASM/$FILE.wasm

--- a/tmp_repl.txt
+++ b/tmp_repl.txt
@@ -79,6 +79,8 @@ cargo run --bin compiler
 
 cargo run --bin compiler -- -f examples/simple_test.pmd
 
+cargo run --bin compiler -- -f examples/closure_test.pmd
+
 # ===WASM Runtime Support===
 
 cargo build


### PR DESCRIPTION
* Make compiling/pretty-printing deterministic (preserves original source ordering of declarations)
* Can compile Polymede ~> GMM:
** constructors
** match statements with non-nested patterns
** let-bindings
** closures
** functions calls 
* No compilation of nested pattern-matching
* No compilation of folds