### PR TITLE
Garbage Collector

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -2,6 +2,15 @@
 ====Implement proper command tracing at runtime====
 ====Human Readable Error messages====
 
+====Check if variable is used at compile time====
+This is actually important for GC. We can have live heap objects referenced in current environment
+that won't be used in further computation, yet GC will think that they are live so won't collect them
+and you can get unnecessary out of memory crash.
+
+====Tail Calls====
+You can use wat2wasm ... --enable-tail-calls.
+Then use instructions `return_call` and `return_call_indirect`. Won't work on Safari right now, but hey, whatever.
+
 ====In runtime environments use Display instead of copying everything====
 
 ====Make semantically different identifier types into different types (wrap them in structs)====

--- a/ast/src/desugared_base.rs
+++ b/ast/src/desugared_base.rs
@@ -99,7 +99,7 @@ fn desugar_do_expression(bindings: &[base::DoBinding], body: &base::Term) -> Ter
 
     fn desugar_neighbouring_binds<'a>(mut bindings: &'a [base::DoBinding], let_bindings: &mut Vec<(Variable, Term)>) -> &'a [base::DoBinding] {
         use base::DoBinding::*;
-        while let Bind(var, term) = &bindings[0] {
+        while let Some(Bind(var, term)) = bindings.get(0) {
             let_bindings.push((var.clone(), desugar_term(term)));
             bindings = &bindings[1..];
         }

--- a/runtime/src/memory_inspect.js
+++ b/runtime/src/memory_inspect.js
@@ -21,6 +21,11 @@ function Tuple(variant, components, address) {
   return { type: "Tuple",  variant, components, address };
 }
 
+// TODO: May be useful during GC inspection.
+function Moved(pointer) {
+  return { type: "Moved", pointer };
+}
+
 function Array(byte_count, bytes, address) {
   return { type: "Array",  byte_count, bytes, address };
 }

--- a/runtime/src/run_wasm.js
+++ b/runtime/src/run_wasm.js
@@ -3,12 +3,8 @@ const { showValue, showValueWithAddress, showStack, showStackWithAddress, deepRe
 const { perform } = require("./perform_command.js");
 
 function run(bytes) {
-  // TODO: Once GC is implemented, don't forget to increase the memory
   const stack_pages = 16;
-  // const heap_pages = 256;
-  // TODO: This is for debugging
-  // const stack_pages = 1;
-  const heap_pages = 1;
+  const heap_pages = 256;
   const total_pages = stack_pages + 2*heap_pages;
 
   const page_byte_size = 2**16; // 65 KB
@@ -30,10 +26,6 @@ function run(bytes) {
   const STACK_START  = new WebAssembly.Global({ value: "i32", mutable: false }, 0)
   const A_HEAP_START = new WebAssembly.Global({ value: "i32", mutable: true }, stack_byte_size);
   const B_HEAP_START = new WebAssembly.Global({ value: "i32", mutable: true }, stack_byte_size + heap_byte_size);
-  // TODO: Revert to the above!
-  // TODO: This is for debugging
-  // const A_HEAP_START = new WebAssembly.Global({ value: "i32", mutable: true }, 2**16 + 2**14);
-  // const B_HEAP_START = new WebAssembly.Global({ value: "i32", mutable: true }, 2**16 + 2**16);
 
   const FREE = new WebAssembly.Global({ value: "i32", mutable: true }, A_HEAP_START.valueOf());
 
@@ -107,14 +99,12 @@ function run(bytes) {
     console.log("> Instantiated succesfully.");
     log_heap_meta()
 
-    // console.log(main);
-
     make_env(0);
     main();
     drop_env();
 
     console.log("> Main executed succesfully.");
-    // log_stack("");
+    // log_stack(0);
     console.log("> Performing command...");
 
     perform(
@@ -125,112 +115,9 @@ function run(bytes) {
       GLOBAL.STACK_START,
       GLOBAL.STACK,
     );
-    // log_stack("");
-
-    // ============GC Debugging============
-    console.log("=======GC Debugging==========")
-    log_heap_meta();
-    // TODO: Just disable main() and perform()
-    //       and create custom stack and perform gc manually.
-
-    // const_(16);
-    // const_(32);
-    // const_(64);
-    // tuple(1234, 2);
-    // const_(128);
-    // tuple(1235, 2); 
-    // log_stack(0);
-
-    // ==manual stack walk==
-    // FREE.value = B_HEAP_START.value;
-    // console.log(readRawPointer(view, 5));
-    // var moved_to0 = gc_move_tuple(81936);
-    // console.log("Moved to", moved_to0);
-    // // I need to refresh the stack.
-    // view.setInt32(6, moved_to0, true);
-
-    // ==auto stack walk==
-    // FREE.value = B_HEAP_START.value;
-    // gc_walk_stack()
-
-
-
-    // Here the 1235 tuple is moved, and is grey (i.e. its first component points to A-space, so we need to move that too)
-    // gc();
-    // log_heap_meta();
     // log_stack(1);
-    // gc();
-    // log_heap_meta();
-    // log_stack(2);
-    // TODO: What is going wrong?
-
-    // const TAGGED_POINTER_BYTE_SIZE = 5;
-    //
-    // const variant_offset = 1;
-    // const count_offset = variant_offset + 4;
-    // const components_offset = count_offset + 1;
-    // log_stack(0);
-    // let raw_pointer = get_tuple_pointer();
-    // log_stack(1);
-    // copy_value_to_stack(raw_pointer + components_offset);
-    // log_stack(2);
-    // copy_value_to_stack(raw_pointer + components_offset + TAGGED_POINTER_BYTE_SIZE);
-    // log_stack(3);
-    // const fn_pointer = make_env_from_closure(1);
-    // log_stack(4);
-    // GLOBAL.TABLE.get(fn_pointer)();
-    // log_stack(5);
-
     console.log("> Exiting.");
 
-    //=====
-    // let tagged_pointer = readRawPointer(view, start);
-    // console.log(tagged_pointer);
-    // let tuple0 = readTuple(view, tagged_pointer);
-    // console.log(tuple0);
-    // let tuple1 = readTuple(view, tuple0.components[1]);
-    // console.log(tuple1);
-
-    // const val = deepReadRawPointer(view, GLOBAL.STACK_START.valueOf());
-    // console.log(showValue(val))
-
-    // const_(16);
-    // const_(250);
-    // make_env(2)
-
-    // const_(16);
-    // const_(250);
-    // partial_apply(888, 2)
-    //
-    // console.log(showStackWithAddress(deepReadStack(view, GLOBAL.STACK_START.valueOf(), GLOBAL.STACK.valueOf())));
-    //
-    // // console.log("What is this?", readRawPointer(view, 2079));
-    //
-    // const_(123);
-    // const_(124);
-    // const_(125);
-    // console.log(showStackWithAddress(deepReadStack(view, GLOBAL.STACK_START.valueOf(), GLOBAL.STACK.valueOf())));
-    // make_env_from_closure(3)
-    // console.log(showStackWithAddress(deepReadStack(view, GLOBAL.STACK_START.valueOf(), GLOBAL.STACK.valueOf())));
-    // console.log(showStackWithAddress(deepReadStack(view, GLOBAL.STACK_START.valueOf(), GLOBAL.STACK.valueOf())));
-    // console.log(readStack(view, GLOBAL.STACK_START.valueOf(), 5))
-
-
-    // ===Test===
-    // console.log(showStackWithAddress(deepReadStack(view, GLOBAL.STACK_START.valueOf(), GLOBAL.STACK.valueOf())));
-    // const_(50)
-    // const_(60)
-    // make_env(2)
-    // var_(1)
-    // var_(0)
-    // console.log(showStackWithAddress(deepReadStack(view, GLOBAL.STACK_START.valueOf(), GLOBAL.STACK.valueOf())));
-
-    // console.log("STACK_START == ", GLOBAL.STACK_START.valueOf());
-    // console.log("STACK == ", GLOBAL.STACK.valueOf());
-    // const stack_val = readStack(view, GLOBAL.STACK_START.valueOf(), GLOBAL.STACK.valueOf());
-    // const stack_val = deepReadStack(view, GLOBAL.STACK_START.valueOf(), GLOBAL.STACK.valueOf());
-    // console.log(showStack(stack_val));
-    //=====
   });
 }
 

--- a/runtime/src/wasm/runtime.wat
+++ b/runtime/src/wasm/runtime.wat
@@ -473,7 +473,7 @@
   (func $gc_walk_stack
     (local $current_element i32)
     (local $tag i32)
-    (local $moved_to i32) ;; TODO: delete this
+    (local $moved_to i32)
 
     (local.set $current_element (global.get $STACK_START))
 
@@ -557,7 +557,6 @@
           ;; move the tuple to B, and update the current tagged pointer
           (i32.store
             (i32.add (local.get $current_grey) (i32.const 1))
-            ;; TODO: Do I need to i32.load the current_gray + 1? yep...
             (call $gc_move_tuple (i32.load (i32.add (local.get $current_grey) (i32.const 1)))))
           (local.set $current_grey (i32.add (local.get $current_grey) (global.get $TAGGED_POINTER_BYTE_SIZE)))
         )

--- a/runtime/src/wasm_helpers.js
+++ b/runtime/src/wasm_helpers.js
@@ -39,6 +39,7 @@ function wasm2bytes(wasm_path, module) {
 module.exports.wasm2bytes = wasm2bytes;
 
 function run(bytes, on_instance) {
+  // TODO: This is completely outdated.
 
   function printRawStack(buffer) {
     const array = new Uint8Array(buffer);
@@ -99,7 +100,7 @@ function run(bytes, on_instance) {
   };
 
   WebAssembly.instantiate(bytes, config).then(({ instance }) => {
-    const { init, stack_start, stack, env, heap, free } = instance.exports;
+    const { stack_start, stack, env, heap, free } = instance.exports;
 
     GLOBAL.STACK_START = stack_start;
     GLOBAL.STACK = stack;

--- a/runtime/src/wasm_helpers.js
+++ b/runtime/src/wasm_helpers.js
@@ -99,14 +99,13 @@ function run(bytes, on_instance) {
   };
 
   WebAssembly.instantiate(bytes, config).then(({ instance }) => {
-    const { init, stack_start, stack, env, heap, free, frame } = instance.exports;
+    const { init, stack_start, stack, env, heap, free } = instance.exports;
 
     GLOBAL.STACK_START = stack_start;
     GLOBAL.STACK = stack;
     GLOBAL.ENV = env;
     GLOBAL.HEAP = heap;
     GLOBAL.FREE = free;
-    GLOBAL.FRAME = frame;
 
     on_instance(instance, { GLOBAL, LOG, buffer, config });
   });


### PR DESCRIPTION
Implements Tracing, Copying, stop-the-world GC. See e.g. [Cheney's algorithm](https://en.wikipedia.org/wiki/Cheney%27s_algorithm).

Assume `stack_pages == 16, heap_pages == 1`, then `range(2500)` creates a linked list that takes more than half of available heap memory. So you can't have two such lists on the heap at the same time.
Consider
```
run # Cmd(I32) : do {
, n = range(len<I32>(range(2500)))
. print_int(len<I32>(n))
}
```
This will create the first `xs0 := range(2500)` list, then compute its length, which is again `2500`, afterwards it will attempt to create another `xs1 := range(2500)`. In the middle of creation of `xs1` we run out of heap memory, so computation is paused, and GC is triggered. At this point `xs0` is not reachable from the stack, so it will be collected. Afterwards the computation is resumed and can finish with the newly available space.

But consider a similar program which at first sight might be considered to have the same behaviour.
```
run # Cmd(I32) : do {
, should_be_collected_ofcourse_right_you_think_sure = range(2500)
, xs = range(2500)
. print_int(len<I32>(xs))
}
```
Unfortunately right now compiler is not clever enough not to include `should_be_collected_ofcourse_right_you_think_sure` in the current environment at the runtime, so it is considered alive by GC, so it won't be collected, after which we ran out of memory.