### PR TITLE
Tail calls

### DIFF
--- a/compiler/src/runtime.rs
+++ b/compiler/src/runtime.rs
@@ -24,6 +24,7 @@ pub struct Runtime {
     pub extend_env: FunctionIndex,
     pub var: FunctionIndex,
     pub drop_env: FunctionIndex,
+    pub drop_env_then_shift: FunctionIndex,
     pub partial_apply: FunctionIndex,
     pub make_env_from_closure: FunctionIndex,
     pub pure: FunctionIndex,
@@ -53,6 +54,7 @@ impl Runtime {
         let extend_env = import(module, "extend_env", fn_type(vec![TYPE_I32], vec![]), &mut number_of_runtime_functions);
         let var = import(module, "var", fn_type(vec![TYPE_I32], vec![]), &mut number_of_runtime_functions);
         let drop_env = import(module, "drop_env", fn_type(vec![], vec![]), &mut number_of_runtime_functions);
+        let drop_env_then_shift = import(module, "drop_env_then_shift", fn_type(vec![], vec![]), &mut number_of_runtime_functions);
         let partial_apply = import(module, "partial_apply", fn_type(vec![TYPE_I32, TYPE_I32], vec![]), &mut number_of_runtime_functions);
         let make_env_from_closure = import(module, "make_env_from_closure", fn_type(vec![TYPE_I32], vec![TYPE_I32]), &mut number_of_runtime_functions);
         let pure = import(module, "pure", fn_type(vec![], vec![]), &mut number_of_runtime_functions);
@@ -74,6 +76,7 @@ impl Runtime {
             extend_env,
             var,
             drop_env,
+            drop_env_then_shift,
             partial_apply,
             make_env_from_closure,
             pure,

--- a/runtime/src/perform_command.js
+++ b/runtime/src/perform_command.js
@@ -9,7 +9,7 @@ const components_offset = count_offset + 1;
 function perform(view, operators, TABLE, is_tracing_enabled, STACK_START, STACK) {
   // TODO: Add a flag for tracing.
 
-  const { get_tuple_pointer, perform_primitive_command, unpack_in_reverse, copy_value_to_stack, make_env_from_closure, drop_env } = operators;
+  const { get_tuple_pointer, perform_primitive_command, unpack_in_reverse, copy_value_to_stack, make_env_from_closure } = operators;
   let raw_pointer 
   let number_of_continuations_left = 0; // Counts number of continuations to be done on the stack.
 
@@ -17,7 +17,6 @@ function perform(view, operators, TABLE, is_tracing_enabled, STACK_START, STACK)
     // stack = [..., k, value]
     const fn_pointer = make_env_from_closure(1);
     TABLE.get(fn_pointer)();
-    drop_env();
     number_of_continuations_left -= 1;
     // stack = [..., new_command]
   }

--- a/runtime/src/run_wasm.js
+++ b/runtime/src/run_wasm.js
@@ -99,9 +99,7 @@ function run(bytes) {
     console.log("> Instantiated succesfully.");
     log_heap_meta()
 
-    make_env(0);
     main();
-    drop_env();
 
     console.log("> Main executed succesfully.");
     // log_stack(0);
@@ -109,7 +107,7 @@ function run(bytes) {
 
     perform(
       view,
-      { get_tuple_pointer, perform_primitive_command, unpack_in_reverse, copy_value_to_stack, make_env_from_closure, drop_env  },
+      { get_tuple_pointer, perform_primitive_command, unpack_in_reverse, copy_value_to_stack, make_env_from_closure  },
       GLOBAL.TABLE,
       true, // tracing
       GLOBAL.STACK_START,

--- a/runtime/src/wasm/runtime.wat
+++ b/runtime/src/wasm/runtime.wat
@@ -364,7 +364,7 @@
     (local $stuff_after_env_in_bytes i32)
 
     (local.set $header_start (i32.add (global.get $ENV) (global.get $ENV_HEADER_START_OFFSET)))
-    (local.set $after_env_start (i32.add (global.get $ENV) (i32.load (i32.mul (i32.add (global.get $ENV) (global.get $ENV_COUNTER_OFFSET)) (global.get $TAGGED_POINTER_BYTE_SIZE)))))
+    (local.set $after_env_start (i32.add (global.get $ENV) (i32.mul (i32.load (i32.add (global.get $ENV) (global.get $ENV_COUNTER_OFFSET))) (global.get $TAGGED_POINTER_BYTE_SIZE))))
     (local.set $stuff_after_env_in_bytes (i32.sub (global.get $STACK) (local.get $after_env_start)))
 
     (; ==Reset env== ;)

--- a/wasm/src/base/instructions.rs
+++ b/wasm/src/base/instructions.rs
@@ -18,7 +18,9 @@ pub enum Instruction {
     Br(LabelIndex),
     BrIf(LabelIndex),
     Call(FunctionIndex),
+    ReturnCall(FunctionIndex),
     CallIndirect(TypeIndex, TableIndex),
+    ReturnCallIndirect(TypeIndex, TableIndex),
 
     Return,
 

--- a/wasm/src/binary_format/instructions.rs
+++ b/wasm/src/binary_format/instructions.rs
@@ -24,6 +24,8 @@ impl Instruction {
     pub const RETURN: u8 = 0x0f;
     pub const CALL: u8 = 0x10;
     pub const CALL_INDIRECT: u8 = 0x11;
+    pub const RETURN_CALL: u8 = 0x12;
+    pub const RETURN_CALL_INDIRECT: u8 = 0x13;
 
     pub const END: u8 = 0x0B;
 
@@ -205,7 +207,9 @@ impl Encoder for Instruction {
             Br(i) => InstructionStream::simple_with_index(Self::BR, *i),
             BrIf(i) => InstructionStream::simple_with_index(Self::BR_IF, *i),
             Call(i) => InstructionStream::simple_with_index(Self::CALL, *i),
+            ReturnCall(i) => InstructionStream::simple_with_index(Self::RETURN_CALL, *i),
             CallIndirect(type_i, table_i) => InstructionStream::simple_with_double_index(Self::CALL_INDIRECT, *type_i, *table_i),
+            ReturnCallIndirect(type_i, table_i) => InstructionStream::simple_with_double_index(Self::RETURN_CALL_INDIRECT, *type_i, *table_i),
             Return => InstructionStream::simple(Self::RETURN),
 
             // ===Variables Instructions===

--- a/wasm/src/syntax.rs
+++ b/wasm/src/syntax.rs
@@ -73,7 +73,9 @@ pub enum Expression {
     IfThenElse { type_: BlockType, test: Box<Expression>, then_body: Box<Expression>, else_body: Box<Expression> },
     Br(LabelIndex),
     Call(FunctionIndex, Vec<Expression>),
+    ReturnCall(FunctionIndex, Vec<Expression>),
     CallIndirect(TypeIndex, TableIndex, Vec<Expression>),
+    ReturnCallIndirect(TypeIndex, TableIndex, Vec<Expression>),
     Return(Box<Expression>),
 
     // ===Variable Instructions===
@@ -402,11 +404,23 @@ impl Expression {
                     }
                     instructions.push(instructions::Instruction::Call(index))
                 },
+                Expression::ReturnCall(index, args) => {
+                    for arg in args {
+                        binary_format_instructions(arg, instructions);
+                    }
+                    instructions.push(instructions::Instruction::ReturnCall(index))
+                },
                 Expression::CallIndirect(type_index, table_index, args) => {
                     for arg in args {
                         binary_format_instructions(arg, instructions);
                     }
                     instructions.push(instructions::Instruction::CallIndirect(type_index, table_index))
+                },
+                Expression::ReturnCallIndirect(type_index, table_index, args) => {
+                    for arg in args {
+                        binary_format_instructions(arg, instructions);
+                    }
+                    instructions.push(instructions::Instruction::ReturnCallIndirect(type_index, table_index))
                 },
                 Expression::Return(expr) => {
                     binary_format_instructions(*expr, instructions);
@@ -554,8 +568,16 @@ pub fn call(fn_index: FunctionIndex, args: Vec<Expression>) -> Expression {
     Expression::Call(fn_index, args)
 }
 
+pub fn return_call(fn_index: FunctionIndex, args: Vec<Expression>) -> Expression {
+    Expression::ReturnCall(fn_index, args)
+}
+
 pub fn call_indirect(type_index: TypeIndex, table_index: TableIndex, args: Vec<Expression>) -> Expression {
     Expression::CallIndirect(type_index, table_index, args)
+}
+
+pub fn return_call_indirect(type_index: TypeIndex, table_index: TableIndex, args: Vec<Expression>) -> Expression {
+    Expression::ReturnCallIndirect(type_index, table_index, args)
 }
 
 pub fn i32_memory_get(address: Expression) -> Expression {


### PR DESCRIPTION
Implement tail-calls so that e.g.
```
fn loop = # I32 -> I32 : fn { x .
  loop(add(x, 1))
}
```
can run forever instead of blowing up the stack.