### PR TITLE
Strings and STATIC region

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -7,10 +7,6 @@ This is actually important for GC. We can have live heap objects referenced in c
 that won't be used in further computation, yet GC will think that they are live so won't collect them
 and you can get unnecessary out of memory crash.
 
-====Tail Calls====
-You can use wat2wasm ... --enable-tail-calls.
-Then use instructions `return_call` and `return_call_indirect`. Won't work on Safari right now, but hey, whatever.
-
 ====In runtime environments use Display instead of copying everything====
 
 ====Make semantically different identifier types into different types (wrap them in structs)====

--- a/ast/src/base.rs
+++ b/ast/src/base.rs
@@ -140,6 +140,7 @@ pub enum Type {
     TypeApplication(ConstructorName, Vec<Type>),
     Arrow(Box<FunctionType>),
     I32,
+    String,
     Command(Box<Type>),
 }
 
@@ -161,6 +162,7 @@ pub struct TypedTerm {
 pub enum Term {
     TypedTerm(Box<TypedTerm>),
     Int(i32),
+    StringLiteral(String),
     VariableUse(Variable),
     FunctionApplication(FunctionName, Vec<Type>, Vec<Term>),
     ConstructorUse(ConstructorName, Vec<Term>),
@@ -439,6 +441,7 @@ pub fn type_apply(type_parameters: &[Variable], type_body: &Type, type_arguments
                 Arrow(Box::new(FunctionType { input_types: applied_input_types, output_type: applied_output_type }))
             },
             I32 => I32,
+            String => String,
             Command(type_body) => Command(Box::new(traverse(position_map, type_body, type_arguments))),
         }
     }

--- a/ast/src/desugared_base.rs
+++ b/ast/src/desugared_base.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 pub enum Term {
     TypedTerm(Box<TypedTerm>),
     Int(i32),
+    StringLiteral(String),
     VariableUse(Variable),
     FunctionApplication(FunctionName, Vec<Type>, Vec<Term>),
     ConstructorUse(ConstructorName, Vec<Term>),
@@ -80,6 +81,7 @@ pub fn desugar_term(term: &base::Term) -> Term {
     match term {
         TypedTerm(typed_term) => Term::TypedTerm(Box::new(desugar_typed_term(typed_term))),
         Int(x) => Term::Int(*x),
+        StringLiteral(s) => Term::StringLiteral(s.clone()), // TODO: the .clone() is very unfortunate
         VariableUse(var) => Term::VariableUse(var.clone()),
         FunctionApplication(fn_name, type_args, args) => Term::FunctionApplication(fn_name.clone(), type_args.clone(), args.into_iter().map(desugar_term).collect()),
         ConstructorUse(constructor_name, args) => Term::ConstructorUse(constructor_name.clone(), args.into_iter().map(desugar_term).collect()),
@@ -221,6 +223,7 @@ fn free_variables(env: &mut Env, term: &Term) {
             env.attempt_to_register_free(var)
         },
         Int(_) => {}, 
+        StringLiteral(_) => {},
         FunctionApplication(_, _, args) => {
             for arg in args {
                 free_variables(env, arg)

--- a/ast/src/parser/base.rs
+++ b/ast/src/parser/base.rs
@@ -6,6 +6,7 @@ use crate::parser::lex::{
     token::Keyword,
 };
 use crate::parser::program::pre_program;
+use std::str::Chars;
 
 pub type Result<A> = std::result::Result<A, Error>;
 
@@ -205,6 +206,10 @@ impl <'lex_state, 'interner> State<'lex_state, 'interner> {
         self.lexer_state.commit_if_next_token_int().map_err(Error::LexError)
     }
 
+    pub fn commit_if_next_token_string_literal(&mut self) -> Result<Option<String>> {
+        self.lexer_state.commit_if_next_token_string_literal().map_err(Error::LexError)
+    }
+
     pub fn commit_if_next_token_forall(&mut self) -> Result<bool> {
         self.lexer_state.commit_if_next_token_forall().map_err(Error::LexError)
     }
@@ -215,6 +220,14 @@ impl <'lex_state, 'interner> State<'lex_state, 'interner> {
 
     pub fn clone(&self) -> lexer::State<'lex_state> {
         self.lexer_state.clone()
+    }
+
+    pub fn read_char_or_fail_when_end(&mut self) -> Result<char> {
+        self.lexer_state.read_char_or_fail_when_end().map_err(Error::LexError)
+    }
+
+    pub fn consume_char_or_fail_when_end(&mut self) -> Result<char> {
+        self.lexer_state.consume_char_or_fail_when_end().map_err(Error::LexError)
     }
 
     pub fn restore(&mut self, lexer_state: lexer::State<'lex_state>) {

--- a/ast/src/parser/lex/lexer.rs
+++ b/ast/src/parser/lex/lexer.rs
@@ -2,6 +2,7 @@ use crate::parser::lex::{
     token,
     token::{Token, SeparatorSymbol}
 };
+use std::str::Chars;
 
 type Result<A> = std::result::Result<A, Error>;
 
@@ -101,8 +102,8 @@ impl <'state> State<'state> {
         self.position.column += n;
     }
 
-    pub fn consume_by(&mut self, n: usize) {
-        self.tokens = &self.tokens[n..]
+    pub fn consume_next(&mut self) {
+        self.tokens = &self.tokens[1..]
     }
 
     pub fn consume_whitespace(&mut self) {
@@ -113,15 +114,15 @@ impl <'state> State<'state> {
                     ConsumeWhitespace => match c {
                         '\n' => {
                             state.new_line();
-                            state.consume_by(1);
+                            state.consume_next();
                         },
                         ' ' | '\t' => {
                             state.move_column_by(1);
-                            state.consume_by(1);
+                            state.consume_next();
                         },
                         '/' => {
                             state.move_column_by(1);
-                            state.consume_by(1);
+                            state.consume_next();
                             *ws_state = ConsumeAllUntilNewline;
                         },
                         _ => {
@@ -131,12 +132,12 @@ impl <'state> State<'state> {
                     ConsumeAllUntilNewline => match c {
                         '\n' => {
                             state.move_column_by(1);
-                            state.consume_by(1);
+                            state.consume_next();
                             *ws_state = ConsumeWhitespace;
                         }
                         _ => {
                             state.move_column_by(1);
-                            state.consume_by(1);
+                            state.consume_next();
                         }
                     },
                 }
@@ -151,7 +152,7 @@ impl <'state> State<'state> {
     pub fn advance(&mut self) -> Position {
         let previous_position = self.position;
         self.move_column_by(1);
-        self.consume_by(1);
+        self.consume_next();
         previous_position
     }
 

--- a/ast/src/parser/show.rs
+++ b/ast/src/parser/show.rs
@@ -111,6 +111,7 @@ impl <'show>Show<'show> {
                 format!("Fn({fn_type_str})")
             },
             I32 => "I32".to_string(),
+            String => "String".to_string(),
             Command(type_) => format!("Cmd({})", self.show_type(type_))
         }
     }

--- a/ast/src/parser/special.rs
+++ b/ast/src/parser/special.rs
@@ -45,6 +45,7 @@ pub fn constructor_name_or_variable(state: &mut State) -> Result<VariableOrConst
 pub enum StartTerm {
     TypeAnnotation,
     Int(i32),
+    StringLiteral(String),
     VariableUse(Variable),
     FunctionApplication(Variable),
     ConstructorConstant(ConstructorName),
@@ -99,6 +100,11 @@ pub fn start_term(state: &mut State) -> Result<StartTerm> {
     if state.is_next_token_start_type_annotation()? {
         return Ok(StartTerm::TypeAnnotation)
     } 
+
+    match state.commit_if_next_token_string_literal()? {
+        Some(s) => return Ok(StartTerm::StringLiteral(s)),
+        None => {},
+    }
 
     match state.commit_if_next_token_int()? {
         Some(x) => return Ok(StartTerm::Int(x)),

--- a/ast/src/parser/term.rs
+++ b/ast/src/parser/term.rs
@@ -22,6 +22,7 @@ pub fn term(state: &mut State) -> Result<Term> {
             Ok(Term::TypedTerm(Box::new(TypedTerm {type_, term})))
         },
         StartTerm::Int(x) => Ok(Term::Int(x)),
+        StartTerm::StringLiteral(s) => Ok(Term::StringLiteral(s)),
         StartTerm::VariableUse(variable) => Ok(Term::VariableUse(variable)),
         StartTerm::FunctionApplication(function_name) => {
             let type_args: Vec<Type> = if state.is_next_token_open_angle()? {

--- a/ast/src/parser/types.rs
+++ b/ast/src/parser/types.rs
@@ -13,6 +13,9 @@ use crate::parser::{
 //   x
 //   Cons(T1, T2)
 //   Fn(T1, T2 -> T)
+//   Cmd(T)
+//   I32
+//   String
 pub fn type_(state: &mut State) -> Result<Type> {
     match constructor_name_or_variable(state)? {
         VariableOrConstructorName::Variable(variable) => Ok(Type::VariableUse(variable)),
@@ -41,6 +44,7 @@ pub fn type_(state: &mut State) -> Result<Type> {
                 // A type constant
                 match constructor_name.str(state.interner()) {
                     "I32" => Ok(Type::I32),
+                    "String" => Ok(Type::String),
                     _ => Ok(Type::TypeApplication(constructor_name, vec![])),
                 }
             }

--- a/ast/src/parser/types.rs
+++ b/ast/src/parser/types.rs
@@ -58,9 +58,11 @@ pub fn primitive_type(state: &mut State) -> Result<Type> {
     let t = type_.clone();
     match type_ {
         I32 => Ok(t),
+        String => Ok(t),
         Command(x) =>  {
             match *x {
                 I32 => Ok(t),
+                String => Ok(t),
                 _ => Err(Error::ExpectedPrimitiveType { received: t }),
             }
         },

--- a/ast/src/validation/term_formation.rs
+++ b/ast/src/validation/term_formation.rs
@@ -145,6 +145,7 @@ fn type_infer(env: &mut Environment, term: &Term) -> Result<Type> {
             Ok(type_.clone())
         },
         Int(_) => Ok(Type::I32),
+        StringLiteral(_) => Ok(Type::String),
         VariableUse(var) => {
             match env.get_type(var) {
                 Some(type_) => Ok(type_.clone()),
@@ -264,6 +265,13 @@ fn type_check(env: &mut Environment, term: &Term, expected_type: &Type) -> Resul
                 Ok(())
             } else {
                 Err(Error::TypeAnnotationDoesntMatchExpectedType { expected_type: expected_type.clone(), received_type: Type::I32 })
+            }
+        },
+        StringLiteral(_) => {
+            if eq_type(expected_type, &Type::String) {
+                Ok(())
+            } else {
+                Err(Error::TypeAnnotationDoesntMatchExpectedType { expected_type: expected_type.clone(), received_type: Type::String })
             }
         },
         VariableUse(var) => {

--- a/ast/src/validation/type_formation.rs
+++ b/ast/src/validation/type_formation.rs
@@ -135,6 +135,7 @@ pub fn check_type(program: &Program, type_env: &TypeScope, type_: &Type) -> Resu
             check_function_type(program, type_env, function_type)
         },
         I32 => Ok(()),
+        String => Ok(()),
         Command(type_) => check_type(program, type_env, type_),
     }
 }
@@ -194,6 +195,7 @@ fn check_positive_occurance(type_var0: &Variable, type_: &Type) -> Result<()> {
                 check(type_var0, &function_type.output_type, polarity)
             },
             I32 => Ok(()),
+            String => Ok(()),
             Command(type_) => check(type_var0, type_, polarity),
         }
     }

--- a/compiler/src/gmm_compiler.rs
+++ b/compiler/src/gmm_compiler.rs
@@ -1,11 +1,12 @@
 use crate::graph_memory_machine as gmm;
 use crate::runtime::Runtime;
 use wasm::{
-    syntax::{Module, TypedFunctionImport, TypedFunction, fn_type, Expression, call, return_call, call_indirect, return_call_indirect, i32_const, i32_eq, seq},
+    syntax::{Module, TypedFunctionImport, TypedFunction, Global, MemoryImport, fn_type, Expression, call, return_call, call_indirect, return_call_indirect, i32_const, i32_eq, seq},
     base::{
         indices::{FunctionIndex, TableIndex, TypeIndex},
-        types::{FunctionType, BlockType},
+        types::{FunctionType, BlockType, GlobalType, ValueType, NumType, Mutability},
         export::{Export, ExportDescription},
+        memory::Limit,
     },
 };
 use std::collections::HashMap;
@@ -21,6 +22,8 @@ pub type Result<A> = std::result::Result<A, CompilationError>;
 
 type FunctionTableIndex = i32;
 
+type RawPointerToStatic = i32;
+
 #[derive(Debug)]
 struct State {
     gmm_to_wasm_name_map: HashMap<gmm::FunctionName, FunctionInfo>,
@@ -30,6 +33,9 @@ struct State {
     function_type_for_call_indirect: TypeIndex,
     function_table_map: HashMap<FunctionIndex, FunctionTableIndex>,
     function_table: Vec<FunctionIndex>,
+
+    current_static_offset: RawPointerToStatic,
+    byte_array_store: Vec<(RawPointerToStatic, Vec<u8>)>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -50,11 +56,14 @@ impl State {
         Self {
             gmm_to_wasm_name_map: HashMap::new(),
 
+            runtime,
+
             function_type_for_call_indirect,
             function_table_map: HashMap::new(),
             function_table: vec![],
 
-            runtime,
+            current_static_offset: 0,
+            byte_array_store: vec![],
         }
     }
 
@@ -84,6 +93,13 @@ impl State {
                 Ok(fn_table_index)
             }
         }
+    }
+
+    fn register_byte_array_literal(&mut self, bytes: Vec<u8>) -> RawPointerToStatic {
+        let raw_pointer: RawPointerToStatic = self.current_static_offset;
+        self.current_static_offset += Runtime::BYTE_ARRAY_HEADER_BYTE_SIZE + (bytes.len() as i32);
+        self.byte_array_store.push((raw_pointer, bytes));
+        raw_pointer
     }
 }
 
@@ -144,7 +160,28 @@ pub fn compile(program: gmm::Program) -> Result<Module> {
     module.add_export(Export { name: "main".to_string(), export_description: ExportDescription::Function(main) });
     module.add_export(Export { name: "function_table".to_string(), export_description: ExportDescription::Table(TableIndex(0)) });
 
+    // TODO: This doesnt' work when wasm-merge is used. It is merged in such a way that I have
+    // multiple memory imports. Jesus... I can resolve this by having the string literals compiled
+    // into the code with passive data segments. Afterwards initializing the STATIC manually.
+    //module.add_memory_import(MemoryImport { module_name: "runtime".to_string(), name: "memory".to_string(), limit: Limit::MinToInfinity { min: 0 } });
+
     module.register_function_table(state.function_table);
+
+    {
+        let mut data_table = vec![];
+        for (pointer, bytes) in state.byte_array_store {
+            data_table.push((pointer, Runtime::encode_byte_array(&bytes)));
+        }
+        module.register_data_table(data_table);
+
+        // Global variable that stores the size of the STATIC region in bytes.
+        let static_size_global_index = module.add_global(Global {
+            global_type: GlobalType { type_: ValueType::NumType(NumType::I32), mutability: Mutability::Const },
+            expression: i32_const(state.current_static_offset) 
+        });
+        println!("STATIC_SIZE = {}", state.current_static_offset);
+        module.add_export(Export { name: "STATIC_SIZE".to_string(), export_description: ExportDescription::Global(static_size_global_index) });
+    }
 
     Ok(module)
 }
@@ -188,8 +225,15 @@ fn compile_term(state: &mut State, number_of_parameters: usize, term: &gmm::Term
             if tail_position { code.push(call(state.runtime.drop_env, vec![])) }
             Ok(seq(code))
         },
-        gmm::Term::ByteArray(_bytes) => {
-            todo!()
+        gmm::Term::ByteArray(bytes) => {
+            let mut code = vec![];
+            let byte_count = bytes.len() as i32;
+            // TODO: Again I'm cloning the byte array literal.
+            let pointer = state.register_byte_array_literal(bytes.to_vec());
+            code.push(call(state.runtime.array_slice, vec![i32_const(pointer), i32_const(pointer + Runtime::BYTE_ARRAY_HEADER_BYTE_SIZE), i32_const(byte_count)]));
+
+            if tail_position { code.push(call(state.runtime.drop_env, vec![])) }
+            Ok(seq(code))
         },
         gmm::Term::Tuple(variant, terms) => {
             let mut code: Vec<Expression> = compile_terms(state, number_of_parameters, terms)?;

--- a/compiler/src/polymede_compiler.rs
+++ b/compiler/src/polymede_compiler.rs
@@ -243,6 +243,7 @@ fn compile_term(state: &mut State, term: &desugared_polymede::Term) -> gmm::Term
         TypedTerm(typed_term) => compile_typed_term(state, &typed_term),
         VariableUse(var) => compile_var(state, var),
         Int(x) => gmm::Term::Const(*x) ,
+        StringLiteral(s) => todo!(),
         FunctionApplication(function_name, _, args) => {
             let Some(fn_index) = state.get_function_index(function_name) else { unreachable!() };
             gmm::Term::Call(fn_index, args.iter().map(|arg| compile_term(state, arg)).collect())

--- a/compiler/src/polymede_compiler.rs
+++ b/compiler/src/polymede_compiler.rs
@@ -237,13 +237,16 @@ fn compile_typed_term(state: &mut State, typed_term: &desugared_polymede::TypedT
     compile_term(state, &typed_term.term)
 }
 
+// TODO: Consider introducing two versions for better performance
+//   fn compile_term(state: &mut State, term: &desugared_polymede::Term) -> gmm::Term
+//   fn compile_term(state: &mut State, term: desugared_polymede::Term) -> gmm::Term
 fn compile_term(state: &mut State, term: &desugared_polymede::Term) -> gmm::Term {
     use desugared_polymede::Term::*;
     match term {
         TypedTerm(typed_term) => compile_typed_term(state, &typed_term),
         VariableUse(var) => compile_var(state, var),
         Int(x) => gmm::Term::Const(*x) ,
-        StringLiteral(s) => todo!(),
+        StringLiteral(s) => gmm::Term::ByteArray(s.clone().into_bytes()), // TODO: Again, this clones the string, which really sucks.
         FunctionApplication(function_name, _, args) => {
             let Some(fn_index) = state.get_function_index(function_name) else { unreachable!() };
             gmm::Term::Call(fn_index, args.iter().map(|arg| compile_term(state, arg)).collect())

--- a/compiler/src/runtime.rs
+++ b/compiler/src/runtime.rs
@@ -34,7 +34,7 @@ pub struct Runtime {
 
 impl Runtime {
     pub const BYTE_ARRAY_HEADER_BYTE_SIZE: i32 = 6;
-    pub const BYTE_ARRAY_TAG: u8 = 2;
+    pub const BYTE_ARRAY_TAG: u8 = 3;
     pub const GC_TAG_LIVE: u8 = 0;
 
     pub fn encode_byte_array(bytes: &[u8]) -> Vec<u8> {

--- a/compiler/src/runtime.rs
+++ b/compiler/src/runtime.rs
@@ -29,9 +29,27 @@ pub struct Runtime {
     pub make_env_from_closure: FunctionIndex,
     pub pure: FunctionIndex,
     pub and_then: FunctionIndex,
+    pub array_slice: FunctionIndex,
 }
 
 impl Runtime {
+    pub const BYTE_ARRAY_HEADER_BYTE_SIZE: i32 = 6;
+    pub const BYTE_ARRAY_TAG: u8 = 2;
+    pub const GC_TAG_LIVE: u8 = 0;
+
+    pub fn encode_byte_array(bytes: &[u8]) -> Vec<u8> {
+        // Encoding of Byte Array is as follows
+        //   | gc 1 byte | tag 1 byte | count 4 byte | byte array contents |
+        let count = bytes.len() as i32;
+        let mut result = Vec::with_capacity((Self::BYTE_ARRAY_HEADER_BYTE_SIZE + count) as usize);
+        // Note that WASM encodes ints in little-endian byte order.
+        result.extend_from_slice(&Self::GC_TAG_LIVE.to_le_bytes());  // 1 byte
+        result.extend_from_slice(&Self::BYTE_ARRAY_TAG.to_le_bytes()); // 1 byte
+        result.extend_from_slice(&count.to_le_bytes()); // 4 bytes
+        result.extend_from_slice(bytes);
+        result
+    }
+
     pub fn import(module: &mut Module) -> Self {
         let mut number_of_runtime_functions = 0;
         fn import(module: &mut Module, fn_name: &str, type_: FunctionType, number_of_runtime_functions: &mut usize) -> FunctionIndex {
@@ -59,6 +77,7 @@ impl Runtime {
         let make_env_from_closure = import(module, "make_env_from_closure", fn_type(vec![TYPE_I32], vec![TYPE_I32]), &mut number_of_runtime_functions);
         let pure = import(module, "pure", fn_type(vec![], vec![]), &mut number_of_runtime_functions);
         let and_then = import(module, "and_then", fn_type(vec![], vec![]), &mut number_of_runtime_functions);
+        let array_slice = import(module, "array_slice", fn_type(vec![TYPE_I32, TYPE_I32, TYPE_I32], vec![]), &mut number_of_runtime_functions);
 
         Self {
             number_of_runtime_functions,
@@ -81,6 +100,7 @@ impl Runtime {
             make_env_from_closure,
             pure,
             and_then,
+            array_slice,
         }
     }
 }

--- a/runtime/src/memory_inspect.js
+++ b/runtime/src/memory_inspect.js
@@ -53,8 +53,8 @@ module.exports.readRawPointer = readRawPointer;
 function readTuple(view, tagged_pointer) {
   if (tagged_pointer.tag != "Tuple") { throw Error(`Attempt to read non-tuple as tuple @ ${tagged_pointer}`) }
   const tuple_pointer = tagged_pointer.pointer;
-  // 1 byte for GC, 4 bytes for variant, 1 byte for count, followed by components
-  const variant_offset = 1;
+  // 1 byte for GC, 1 byte for tag, 4 bytes for variant, 1 byte for count, followed by components
+  const variant_offset = 2;
   const count_offset = variant_offset + 4;
   const components_offset = count_offset + 1;
 

--- a/runtime/src/memory_inspect.js
+++ b/runtime/src/memory_inspect.js
@@ -10,6 +10,21 @@ const PARENT_ENV_POINTER_BYTE_SIZE = 4;
 const ENV_COUNTER_BYTE_SIZE = 4;
 const ENV_HEADER_BYTE_SIZE = 1 + PARENT_ENV_POINTER_BYTE_SIZE + ENV_COUNTER_BYTE_SIZE; // 9 bytes, 1 byte for tag, 4 bytes for parent env pointer, 4 bytes for env count.
 
+
+// | gc 1 byte | tag 1 byte | count 4 byte | string contents |
+const BYTE_ARRAY_HEADER_BYTE_SIZE = 6;
+const BYTE_ARRAY_COUNT_OFFSET = 2;
+const BYTE_ARRAY_CONTENTS_OFFSET = 6;
+const BYTE_ARRAY_COUNT_SIZE = 4;
+// | gc 1 byte | tag 1 byte | 1st pointer 4 byte | 2nd pointer 4 byte | count 4 byte |
+const SLICE_BYTE_SIZE = 14;
+const SLICE_PARENT_POINTER_OFFSET = 2;
+const SLICE_POINTER_OFFSET = 6;
+const SLICE_COUNT_OFFSET = 10;
+const SLICE_PARENT_POINTER_SIZE = 4;
+const SLICE_POINTER_SIZE = 4;
+const SLICE_COUNT_SIZE = 4;
+
 function Constant(value, address) {
   return { type: "Const", value, address };
 }
@@ -22,8 +37,8 @@ function Tuple(variant, components, address) {
   return { type: "Tuple",  variant, components, address };
 }
 
-function ByteArraySlice(parent_pointer, pointer, count, address) {
-  return { type: "ByteArraySlice", parent_pointer, pointer, count, address };
+function ByteArraySlice(parent_pointer, pointer, count, contents, address) {
+  return { type: "ByteArraySlice", parent_pointer, pointer, count, contents, address };
 }
 
 // TODO: May be useful during GC inspection.
@@ -81,6 +96,18 @@ function readTuple(view, tagged_pointer) {
 }
 module.exports.readTuple = readTuple;
 
+function readSlice(view, tagged_pointer) {
+  if (tagged_pointer.tag != "ByteArraySlice") { throw Error(`Attempt to read non-slice as a slice @ ${tagged_pointer}`) }
+  const slice_pointer = tagged_pointer.pointer;
+
+  const parent_pointer = view.getInt32(slice_pointer + SLICE_PARENT_POINTER_OFFSET, true);
+  const pointer = view.getInt32(slice_pointer + SLICE_POINTER_OFFSET, true);
+  const count = view.getInt32(slice_pointer + SLICE_COUNT_OFFSET, true);
+
+  return ByteArraySlice(parent_pointer, pointer, count, undefined, slice_pointer);
+}
+module.exports.readSlice = readSlice;
+
 // WARNING: Does not detect cyclic structure.
 function deepReadRawPointer(view, raw_pointer) {
   const tagged_pointer = readRawPointer(view, raw_pointer);
@@ -94,6 +121,8 @@ function deepReadTaggedPointer(view, tagged_pointer) {
   } else if (tagged_pointer.type == "Pointer"){
     if (tagged_pointer.tag == "Tuple") {
       return deepReadTuple(view, tagged_pointer);
+    } else if (tagged_pointer.tag == "ByteArraySlice"){
+      return deepReadSlice(view, tagged_pointer);
     } else {
       throw Error(`We have a pointer that's not a tuple ${tagged_pointer}`);
     }
@@ -112,6 +141,13 @@ function deepReadTuple(view, tagged_pointer) {
   return Tuple(tuple.variant, components, tuple.address);
 }
 module.exports.deepReadTuple = deepReadTuple;
+
+function deepReadSlice(view, tagged_pointer) {
+  const slice = readSlice(view, tagged_pointer);
+  const str_view = new DataView(view.buffer, slice.pointer, slice.count)
+  const str = (new TextDecoder()).decode(str_view)
+  return ByteArraySlice(slice.parent_pointer, slice.pointer, slice.count, str, slice.address);
+}
 
 function readStack(view, raw_pointer_start, raw_pointer_end) {
   const stack = [];
@@ -142,9 +178,9 @@ function readStack(view, raw_pointer_start, raw_pointer_end) {
         stack.push(Env(old_env_pointer, values, raw_pointer));
         readNextValue(raw_pointer + ENV_HEADER_BYTE_SIZE + count * TAGGED_POINTER_BYTE_SIZE);
       } else if (tag == BYTE_ARRAY_SLICE_TAG) {
-        throw Error("Slices not yet implemented");
-      } else if (tag == BYTE_ARRAY_TAG) {
-        throw Error("Arrays not yet implemented");
+        const slice_pointer = view.getInt32(raw_pointer + 1, true);
+        stack.push(TaggedPointer("ByteArraySlice", slice_pointer, raw_pointer));
+        readNextValue(raw_pointer + TAGGED_POINTER_BYTE_SIZE)
       } else {
         throw Error(`Unknown value Tag ${tag}`);
       }
@@ -172,7 +208,7 @@ function deepReadStack(view, raw_pointer_start, raw_pointer_end) {
         const tuple_pointer = view.getInt32(raw_pointer + 1, true);
         const tagged_pointer = TaggedPointer("Tuple", tuple_pointer);
         stack.push(deepReadTuple(view, tagged_pointer));
-        readNextValue(raw_pointer + TAGGED_POINTER_BYTE_SIZE)
+        readNextValue(raw_pointer + TAGGED_POINTER_BYTE_SIZE);
       } else if (tag == ENV_TAG) {
         const old_env_pointer = view.getInt32(raw_pointer + 1, true);
         const count = view.getInt32(raw_pointer + 1 + PARENT_ENV_POINTER_BYTE_SIZE, true);
@@ -186,9 +222,10 @@ function deepReadStack(view, raw_pointer_start, raw_pointer_end) {
         stack.push(Env(old_env_pointer, values, raw_pointer));
         readNextValue(raw_pointer + ENV_HEADER_BYTE_SIZE + count * TAGGED_POINTER_BYTE_SIZE);
       } else if (tag == BYTE_ARRAY_SLICE_TAG) {
-        throw Error("Slices not yet implemented");
-      } else if (tag == BYTE_ARRAY_TAG) {
-        throw Error("Arrays not yet implemented");
+        const slice_pointer = view.getInt32(raw_pointer + 1, true);
+        const tagged_pointer = TaggedPointer("ByteArraySlice", slice_pointer);
+        stack.push(deepReadSlice(view, tagged_pointer));
+        readNextValue(raw_pointer + TAGGED_POINTER_BYTE_SIZE);
       } else {
         throw Error(`Unknown value Tag ${tag}`);
       }
@@ -215,6 +252,8 @@ function showValue(x) {
       values_str.push(showValue(value));
     });
     return `Env[#${x.old_env_pointer}](${values_str.join(", ")})`;
+  } else if (x.type == "ByteArraySlice") {
+    return `Slice[parent:=${x.parent_pointer}, p:=${x.pointer}, c:=${x.count}]("${x.contents}")`;
   } else if (x.type == "ByteArray") {
     throw Error("Arrays not yet implemented");
   } else {
@@ -238,6 +277,8 @@ function showValueWithAddress(x) {
       values_str.push(showValueWithAddress(value));
     });
     return `Env@${x.address}[#${x.old_env_pointer}](${values_str.join(", ")})`;
+  } else if (x.type == "ByteArraySlice") {
+    return `Slice@${x.address}[parent:=${x.parent_pointer}, p:=${x.pointer}, c:=${x.count}]("${x.contents}")`;
   } else if (x.type == "ByteArray") {
     throw Error("Arrays not yet implemented");
   } else {

--- a/runtime/src/memory_inspect.js
+++ b/runtime/src/memory_inspect.js
@@ -1,7 +1,8 @@
 const ENV_TAG = 0;
 const CONST_TAG = 1;
-const ARRAY_TAG = 2;
-const TUPLE_TAG = 3;
+const TUPLE_TAG = 2;
+const ARRAY_TAG = 3;
+const ARRAY_SLICE_TAG = 4;
 
 const TAGGED_POINTER_BYTE_SIZE = 5;
 

--- a/runtime/src/perform_command.js
+++ b/runtime/src/perform_command.js
@@ -2,7 +2,7 @@ const { showValue, showValueWithAddress, showStack, showStackWithAddress, deepRe
 
 const TAGGED_POINTER_BYTE_SIZE = 5;
 
-const variant_offset = 1;
+const variant_offset = 2;
 const count_offset = variant_offset + 4;
 const components_offset = count_offset + 1;
 

--- a/runtime/src/run_wasm.js
+++ b/runtime/src/run_wasm.js
@@ -15,12 +15,8 @@ function run(bytes) {
 
     const page_byte_size = 2**16; // 65 KB
     const static_pages = Math.ceil(static_byte_size / page_byte_size);
-    // TODO: Revert to the below
-    // const stack_pages = 16;
-    // const heap_pages = 256;
-    // TODO: Delete
     const stack_pages = 16;
-    const heap_pages = 1;
+    const heap_pages = 256;
     const total_pages = static_pages + stack_pages + 2*heap_pages;
 
     const stack_byte_size = page_byte_size * stack_pages; // 1 MB. Note that this is Linear Stack in Linear Memory, not the wasm's stack.

--- a/runtime/src/run_wasm.js
+++ b/runtime/src/run_wasm.js
@@ -119,7 +119,7 @@ function run(bytes) {
 
     WebAssembly.instantiate(module, config).then(instance => {
         const { main, stack, env, free, function_table, STATIC_SIZE } = instance.exports;
-        const { make_env, make_env_from, make_env_from_closure, drop_env, tuple, partial_apply, get_tuple_pointer, perform_primitive_command, unpack_in_reverse, copy_value_to_stack } = instance.exports;
+        const { make_env, make_env_from, make_env_from_closure, drop_env, array_slice, tuple, partial_apply, get_tuple_pointer, perform_primitive_command, unpack_in_reverse, copy_value_to_stack } = instance.exports;
         const { gc, gc_move_tuple, gc_traverse_grey, gc_walk_stack } = instance.exports;
 
         const const_ = instance.exports["const"];
@@ -138,8 +138,11 @@ function run(bytes) {
 
         main();
 
+        // console.log(array_slice);
+        // array_slice(0, 6, 3);
+
         console.log("> Main executed succesfully.");
-        // log_stack(0);
+        log_stack(0);
         console.log("> Performing command...");
 
         perform(
@@ -150,7 +153,7 @@ function run(bytes) {
           GLOBAL.STACK_START,
           GLOBAL.STACK,
         );
-        // log_stack(1);
+        log_stack(1);
         console.log("> Exiting.");
 
     });

--- a/runtime/src/run_wasm.js
+++ b/runtime/src/run_wasm.js
@@ -14,10 +14,13 @@ function run(bytes) {
     const static_byte_size = STATIC_BUFFER.byteLength;
 
     const page_byte_size = 2**16; // 65 KB
-    // TODO: How many pages should I allocate for static?
     const static_pages = Math.ceil(static_byte_size / page_byte_size);
+    // TODO: Revert to the below
+    // const stack_pages = 16;
+    // const heap_pages = 256;
+    // TODO: Delete
     const stack_pages = 16;
-    const heap_pages = 256;
+    const heap_pages = 1;
     const total_pages = static_pages + stack_pages + 2*heap_pages;
 
     const stack_byte_size = page_byte_size * stack_pages; // 1 MB. Note that this is Linear Stack in Linear Memory, not the wasm's stack.
@@ -127,7 +130,7 @@ function run(bytes) {
         main();
 
         console.log("> Main executed succesfully.");
-        // log_stack(0);
+        log_stack(0);
         console.log("> Performing command...");
 
         perform(
@@ -138,7 +141,7 @@ function run(bytes) {
           GLOBAL.STACK_START,
           GLOBAL.STACK,
         );
-        // log_stack(1);
+        log_stack(1);
         console.log("> Exiting.");
 
     });

--- a/runtime/src/run_wasm.js
+++ b/runtime/src/run_wasm.js
@@ -104,6 +104,15 @@ function run(bytes) {
         log_two_ints(x, y) {
           console.log("Logging two ints", x, y);
         },
+        log_string(pointer, byte_count) {
+          // console.log("pointer", pointer);
+          // console.log("byte_count", byte_count);
+
+          const string_view = new DataView(memory.buffer, pointer,byte_count);
+          let utf8decoder = new TextDecoder();
+          let s = utf8decoder.decode(string_view);
+          console.log(s);
+        }
       },
     };
 
@@ -130,18 +139,18 @@ function run(bytes) {
         main();
 
         console.log("> Main executed succesfully.");
-        log_stack(0);
+        // log_stack(0);
         console.log("> Performing command...");
 
         perform(
           view,
           { get_tuple_pointer, perform_primitive_command, unpack_in_reverse, copy_value_to_stack, make_env_from_closure  },
           GLOBAL.TABLE,
-          true, // tracing
+          false, // tracing
           GLOBAL.STACK_START,
           GLOBAL.STACK,
         );
-        log_stack(1);
+        // log_stack(1);
         console.log("> Exiting.");
 
     });

--- a/runtime/src/run_wasm.js
+++ b/runtime/src/run_wasm.js
@@ -3,119 +3,145 @@ const { showValue, showValueWithAddress, showStack, showStackWithAddress, deepRe
 const { perform } = require("./perform_command.js");
 
 function run(bytes) {
-  const stack_pages = 16;
-  const heap_pages = 256;
-  const total_pages = stack_pages + 2*heap_pages;
 
-  const page_byte_size = 2**16; // 65 KB
-  const stack_byte_size = page_byte_size * stack_pages; // 1 MB. Note that this is Linear Stack in Linear Memory, not the wasm's stack.
-  const heap_byte_size = page_byte_size * heap_pages; // 16 MB
-  const total_byte_size = page_byte_size * total_pages; // (1 + 2*16) MB == 33 MB
+  WebAssembly.compile(bytes).then((module) => {
+    const POLYMEDE_STATIC_CUSTOM_SECTION = WebAssembly.Module.customSections(module, "POLYMEDE_STATIC");
+    if (POLYMEDE_STATIC_CUSTOM_SECTION.length == 0) {
+      throw Error("wasm module doesn't contain POLYMEDE_STATIC custom section. Did you get your order of wasm-merge arguments wrong (it can strip custom sections in the wrong order)?");
+    }
 
-  function log_meta() {
-    console.log('page_byte_size =', page_byte_size);
-    console.log('stack_byte_size =', stack_byte_size);
-    console.log('heap_byte_size =', heap_byte_size);
-    console.log('total_byte_size =', total_byte_size);
-  }
-  log_meta();
+    const STATIC_BUFFER = POLYMEDE_STATIC_CUSTOM_SECTION[0];
+    const static_byte_size = STATIC_BUFFER.byteLength;
 
-  const memory = new WebAssembly.Memory({ initial: total_pages, maximum: total_pages }); // 37 MB
-  const STACK_SIZE = new WebAssembly.Global({ value: "i32", mutable: false }, stack_byte_size);
-  const HEAP_SIZE  = new WebAssembly.Global({ value: "i32", mutable: false }, heap_byte_size);
-  const STACK_START  = new WebAssembly.Global({ value: "i32", mutable: false }, 0)
-  const A_HEAP_START = new WebAssembly.Global({ value: "i32", mutable: true }, stack_byte_size);
-  const B_HEAP_START = new WebAssembly.Global({ value: "i32", mutable: true }, stack_byte_size + heap_byte_size);
+    const page_byte_size = 2**16; // 65 KB
+    // TODO: How many pages should I allocate for static?
+    const static_pages = Math.ceil(static_byte_size / page_byte_size);
+    const stack_pages = 16;
+    const heap_pages = 256;
+    const total_pages = static_pages + stack_pages + 2*heap_pages;
 
-  const FREE = new WebAssembly.Global({ value: "i32", mutable: true }, A_HEAP_START.valueOf());
+    const stack_byte_size = page_byte_size * stack_pages; // 1 MB. Note that this is Linear Stack in Linear Memory, not the wasm's stack.
+    const heap_byte_size = page_byte_size * heap_pages; // 16 MB
+    const total_used_byte_size = static_byte_size + stack_byte_size + 2*heap_byte_size;
+    const total_allocated_byte_size = page_byte_size * total_pages; // (1 + 2*16) MB == 33 MB (not counting STATIC)
 
+    const memory = new WebAssembly.Memory({ initial: total_pages, maximum: total_pages }); // 37 MB (not counting STATIC)
+    const STACK_SIZE = new WebAssembly.Global({ value: "i32", mutable: false }, stack_byte_size);
+    const HEAP_SIZE  = new WebAssembly.Global({ value: "i32", mutable: false }, heap_byte_size);
+    const STATIC_START = new WebAssembly.Global({ value: "i32", mutable: false }, 0);
+    const STACK_START  = new WebAssembly.Global({ value: "i32", mutable: false }, static_byte_size)
+    const A_HEAP_START = new WebAssembly.Global({ value: "i32", mutable: true }, static_byte_size + stack_byte_size);
+    const B_HEAP_START = new WebAssembly.Global({ value: "i32", mutable: true }, static_byte_size + stack_byte_size + heap_byte_size);
 
-  const GLOBAL = {};
-  const view = new DataView(memory.buffer);
+    const FREE = new WebAssembly.Global({ value: "i32", mutable: true }, A_HEAP_START.valueOf());
 
-  function log_stack(s) {
-    console.log(s, showStackWithAddress(deepReadStack(view, GLOBAL.STACK_START.valueOf(), GLOBAL.STACK.valueOf())));
-  }
+    const GLOBAL = {};
 
-  function log_heap_meta() {
-    console.log(`A_HEAP = ${GLOBAL.A_HEAP_START.valueOf()}, B_HEAP = ${GLOBAL.B_HEAP_START.valueOf()}`);
-  }
+    function log_meta() {
+      console.log('static_byte_size =', static_byte_size);
+      console.log('page_byte_size =', page_byte_size);
+      console.log('stack_byte_size =', stack_byte_size);
+      console.log('heap_byte_size =', heap_byte_size);
+      console.log('total_used_byte_size =', total_used_byte_size);
+      console.log(`total_allocated_byte_size = ${total_allocated_byte_size} = pages * page_size = ${total_pages} * ${page_byte_size}`);
+    }
+    log_meta();
 
-  const config = {
-    env: {
-      memory,
-      STACK_SIZE,
-      HEAP_SIZE,
-      STACK_START,
-      A_HEAP_START,
-      B_HEAP_START,
-      FREE,
+    const view = new DataView(memory.buffer);
 
-      on_stack_overflow: () => {
-        throw Error("Linear Stack Overflow!");
+    // ===Copy the STATIC region to Linear Memory===
+    const static_view = new DataView(STATIC_BUFFER);
+    for (let i = 0; i < static_byte_size; i++) {
+      // TODO: There must be a much better way of copying one buffer into another.
+      view.setUint8(i, static_view.getUint8(i));
+    }
+
+    function log_stack(s) {
+      console.log(s, showStackWithAddress(deepReadStack(view, GLOBAL.STACK_START.valueOf(), GLOBAL.STACK.valueOf())));
+    }
+
+    function log_heap_meta() {
+      console.log(`A_HEAP = ${GLOBAL.A_HEAP_START.valueOf()}, B_HEAP = ${GLOBAL.B_HEAP_START.valueOf()}`);
+    }
+
+    const config = {
+      env: {
+        memory,
+        STACK_SIZE,
+        HEAP_SIZE,
+        STACK_START,
+        A_HEAP_START,
+        B_HEAP_START,
+        FREE,
+        STATIC_START,
+
+        on_stack_overflow: () => {
+          throw Error("Linear Stack Overflow!");
+        },
+        on_garbage_collection: () => {
+          console.log("========Performing GC===========");
+        },
+        on_out_of_memory: () => {
+          throw Error("Out of heap memory!");
+        },
+        debug_int: (x) => {
+          console.log("DEBUGGING x =", x);
+        },
+        debug: () => {
+          console.log("DEBUGGING");
+        },
+        show_stack: (x) => {
+          log_stack(x);
+        },
       },
-      on_garbage_collection: () => {
-        console.log("========Performing GC===========");
+      console: {
+        log_int(x) {
+          console.log(x);
+        },
+        log_two_ints(x, y) {
+          console.log("Logging two ints", x, y);
+        },
       },
-      on_out_of_memory: () => {
-        throw Error("Out of heap memory!");
-      },
-      debug_int: (x) => {
-        console.log("DEBUGGING x =", x);
-      },
-      debug: () => {
-        console.log("DEBUGGING");
-      },
-      show_stack: (x) => {
-        log_stack(x);
-      },
-    },
-    console: {
-      log_int(x) {
-        console.log(x);
-      },
-      log_two_ints(x, y) {
-        console.log("Logging two ints", x, y);
-      },
-    },
-  };
+    };
 
-  WebAssembly.instantiate(bytes, config).then(({ instance }) => {
-    const { main, stack, env, free, function_table } = instance.exports;
-    const { make_env, make_env_from, make_env_from_closure, drop_env, tuple, partial_apply, get_tuple_pointer, perform_primitive_command, unpack_in_reverse, copy_value_to_stack } = instance.exports;
-    const { gc, gc_move_tuple, gc_traverse_grey, gc_walk_stack } = instance.exports;
-    
-    const const_ = instance.exports["const"];
-    const var_ = instance.exports["var"];
 
-    GLOBAL.STACK_START = config.env.STACK_START;
-    GLOBAL.A_HEAP_START = config.env.A_HEAP_START;
-    GLOBAL.B_HEAP_START = config.env.B_HEAP_START;
-    GLOBAL.STACK = stack;
-    GLOBAL.ENV = env;
-    GLOBAL.FREE = free;
-    GLOBAL.TABLE = function_table;
+    WebAssembly.instantiate(module, config).then(instance => {
+        const { main, stack, env, free, function_table, STATIC_SIZE } = instance.exports;
+        const { make_env, make_env_from, make_env_from_closure, drop_env, tuple, partial_apply, get_tuple_pointer, perform_primitive_command, unpack_in_reverse, copy_value_to_stack } = instance.exports;
+        const { gc, gc_move_tuple, gc_traverse_grey, gc_walk_stack } = instance.exports;
 
-    console.log("> Instantiated succesfully.");
-    log_heap_meta()
+        const const_ = instance.exports["const"];
+        const var_ = instance.exports["var"];
 
-    main();
+        GLOBAL.STACK_START = config.env.STACK_START;
+        GLOBAL.A_HEAP_START = config.env.A_HEAP_START;
+        GLOBAL.B_HEAP_START = config.env.B_HEAP_START;
+        GLOBAL.STACK = stack;
+        GLOBAL.ENV = env;
+        GLOBAL.FREE = free;
+        GLOBAL.TABLE = function_table;
 
-    console.log("> Main executed succesfully.");
-    // log_stack(0);
-    console.log("> Performing command...");
+        console.log("> Instantiated succesfully.");
+        log_heap_meta()
 
-    perform(
-      view,
-      { get_tuple_pointer, perform_primitive_command, unpack_in_reverse, copy_value_to_stack, make_env_from_closure  },
-      GLOBAL.TABLE,
-      true, // tracing
-      GLOBAL.STACK_START,
-      GLOBAL.STACK,
-    );
-    // log_stack(1);
-    console.log("> Exiting.");
+        main();
 
+        console.log("> Main executed succesfully.");
+        // log_stack(0);
+        console.log("> Performing command...");
+
+        perform(
+          view,
+          { get_tuple_pointer, perform_primitive_command, unpack_in_reverse, copy_value_to_stack, make_env_from_closure  },
+          GLOBAL.TABLE,
+          true, // tracing
+          GLOBAL.STACK_START,
+          GLOBAL.STACK,
+        );
+        // log_stack(1);
+        console.log("> Exiting.");
+
+    });
   });
 }
 

--- a/runtime/src/wasm/primitives.wat
+++ b/runtime/src/wasm/primitives.wat
@@ -6,6 +6,7 @@
   (import "runtime" "get_array_slice_pointer" (func $get_array_slice_pointer (result i32)))
   (import "runtime" "get_array_slice_count" (func $get_array_slice_count (result i32)))
   (import "runtime" "gc" (func $gc))
+  (import "runtime" "concat_slices" (func $concat_slices))
 
   ;; console_log_int(x)
   (import "console" "log_int" (func $console_log_int (param i32)))
@@ -37,6 +38,12 @@
 
   (func $dec (call $const (i32.sub (call $get_const) (i32.const 1))))
   (export "i32_dec" (func $dec))
+
+  ;; Stirng, String -> String
+  (func $string_concat
+    ;; TODO: do a swap
+    (call $concat_slices))
+  (export "string_concat" (func $string_concat))
 
   (func $garbage_collection
     (call $gc)
@@ -97,7 +104,6 @@
 
     (if (i32.eq (local.get $op_code) (global.get $OP_CODE_PRINT_STRING))
     (then
-      ;; TODO: Here you need to print the string...
       (call $dup)
       (call $console_log_string (call $get_array_slice_pointer) (call $get_array_slice_count))
       (call $const (i32.const 123456)))

--- a/runtime/src/wasm/primitives.wat
+++ b/runtime/src/wasm/primitives.wat
@@ -1,11 +1,18 @@
 (module
   (import "runtime" "const" (func $const (param i32)))
   (import "runtime" "get_const" (func $get_const (result i32)))
+  (import "runtime" "dup" (func $dup))
   (import "runtime" "tuple" (func $tuple (param i32) (param i32)))
+  (import "runtime" "get_array_slice_pointer" (func $get_array_slice_pointer (result i32)))
+  (import "runtime" "get_array_slice_count" (func $get_array_slice_count (result i32)))
   (import "runtime" "gc" (func $gc))
 
+  ;; console_log_int(x)
   (import "console" "log_int" (func $console_log_int (param i32)))
+  ;; console_log_two_ints(x, y)
   (import "console" "log_two_ints" (func $console_log_two_ints (param i32) (param i32)))
+  ;; console_log_string(raw_pointer_to_start_of_string_bytes, byte_count)
+  (import "console" "log_string" (func $console_log_string (param i32) (param i32)))
 
   (func $add (call $const (i32.add (call $get_const) (call $get_const))))
   (export "i32_add" (func $add))
@@ -43,6 +50,7 @@
   ;; and 1 is reserved for `and_then`.
   (global $OP_CODE_PRINT_INT i32 (i32.const 13))
   (global $OP_CODE_PRINT_TWO_INTS i32 (i32.const 14))
+  (global $OP_CODE_PRINT_STRING i32 (i32.const 15))
 
   ;; WARNING: When adding a new system-call, don't forget the arity!
 
@@ -62,21 +70,40 @@
     (call $tuple (global.get $OP_CODE_PRINT_TWO_INTS) (i32.const 2)))
   (export "print_two_ints" (func $print_two_ints))
 
+  ;; String -> Cmd(I32)
+  (func $print_string 
+    ;; We can assume that there is a tagged pointer on top of the stack to a string slice.
+    ;; Replace the pointer with a tuple whose variant is a system-call code,
+    ;; and that has 1 component that's the integer
+    (call $tuple (global.get $OP_CODE_PRINT_STRING) (i32.const 1)))
+  (export "print_string" (func $print_string))
+
   ;; Takes in the system-code as input,
   ;; performs the side-effect, and eventually
   ;; could put the result on the stack if there is any.
   (func $perform_primitive_command (param $op_code i32)
     (if (i32.eq (local.get $op_code) (global.get $OP_CODE_PRINT_INT))
-      (then
-        (call $console_log_int (call $get_const))
-        ;; Always returns 0 (because we don't have a builtin Unit type, so it must return something) 
-        (call $const (i32.const 0)))
-      (else
-      (if (i32.eq (local.get $op_code) (global.get $OP_CODE_PRINT_TWO_INTS))
-        (then
-          (call $console_log_two_ints (call $get_const) (call $get_const))
-          (call $const (i32.const 123456)))
-        (else
-        unreachable)))))
+    (then
+      (call $console_log_int (call $get_const))
+      ;; Always returns 0 (because we don't have a builtin Unit type, so it must return something) 
+      (call $const (i32.const 0)))
+    (else
+
+    (if (i32.eq (local.get $op_code) (global.get $OP_CODE_PRINT_TWO_INTS))
+    (then
+      (call $console_log_two_ints (call $get_const) (call $get_const))
+      (call $const (i32.const 123456)))
+    (else
+
+    (if (i32.eq (local.get $op_code) (global.get $OP_CODE_PRINT_STRING))
+    (then
+      ;; TODO: Here you need to print the string...
+      (call $dup)
+      (call $console_log_string (call $get_array_slice_pointer) (call $get_array_slice_count))
+      (call $const (i32.const 123456)))
+    (else
+
+        unreachable))))))
+  )
   (export "perform_primitive_command" (func $perform_primitive_command))
 )

--- a/runtime/src/wasm/primitives.wat
+++ b/runtime/src/wasm/primitives.wat
@@ -2,6 +2,7 @@
   (import "runtime" "const" (func $const (param i32)))
   (import "runtime" "get_const" (func $get_const (result i32)))
   (import "runtime" "tuple" (func $tuple (param i32) (param i32)))
+  (import "runtime" "gc" (func $gc))
 
   (import "console" "log_int" (func $console_log_int (param i32)))
   (import "console" "log_two_ints" (func $console_log_two_ints (param i32) (param i32)))
@@ -30,6 +31,11 @@
   (func $dec (call $const (i32.sub (call $get_const) (i32.const 1))))
   (export "i32_dec" (func $dec))
 
+  (func $garbage_collection
+    (call $gc)
+    (call $const (i32.const 1))
+  )
+  (export "garbage_collection" (func $garbage_collection))
 
   ;; TODO: This whole thing needs to be replaced by function tables, no?
   ;; For some magical reason 13 is for printing an integer.

--- a/runtime/src/wasm/runtime.wat
+++ b/runtime/src/wasm/runtime.wat
@@ -32,8 +32,8 @@
   (global $TAGGED_POINTER_BYTE_SIZE i32 (i32.const 5))
   (global $ENV_TAG i32 (i32.const 0))
   (global $CONST_TAG i32 (i32.const 1))
-  (global $BYTE_ARRAY_TAG i32 (i32.const 2))
-  (global $TUPLE_TAG i32 (i32.const 3))
+  (global $TUPLE_TAG i32 (i32.const 2))
+  (global $BYTE_ARRAY_TAG i32 (i32.const 3))
   (global $BYTE_ARRAY_SLICE_TAG i32 (i32.const 4))
 
   (global $GC_TAG_BYTE_SIZE i32 (i32.const 1))

--- a/runtime/src/wasm/runtime.wat
+++ b/runtime/src/wasm/runtime.wat
@@ -62,6 +62,8 @@
   (global $GC_TAG_LIVE i32 (i32.const 0))
   (global $GC_TAG_MOVED i32 (i32.const 1))
 
+
+  (; ===Stack/Heap=== ;)
   (func $inc_stack (param $count i32)
     (if (i32.lt_u (i32.add (global.get $STACK) (local.get $count)) (global.get $STACK_SIZE))
       (then

--- a/wasm/src/binary_format/primitives/byte_stream.rs
+++ b/wasm/src/binary_format/primitives/byte_stream.rs
@@ -131,10 +131,6 @@ pub trait ByteStream {
     fn enclose(self) -> Enclose<Self> where Self: Sized {
         Enclose::new(self)
     }
-
-    fn vec(bytes: &[u8]) -> Bytes {
-        Bytes::new(bytes.to_vec())
-    }
 }
 
 // ===Sequence===

--- a/wasm/src/binary_format/sections.rs
+++ b/wasm/src/binary_format/sections.rs
@@ -1,4 +1,4 @@
-use crate::binary_format::primitives::byte_stream::{ByteStream, UTF8, string, Response, Enclose, EVec, evector, bytes4, byte, Byte, Bytes4, Bytes, bytes, CVec, cvector, Seq, U32ToFixed40LEB128};
+use crate::binary_format::primitives::byte_stream::{ByteStream, UTF8, string, Response, Enclose, EVec, evector, bytes4, byte, Byte, Bytes4, Bytes, bytes, Vector, vector, CVec, cvector, Seq, U32ToFixed40LEB128};
 use crate::binary_format::primitives::encoder::Encoder;
 use crate::binary_format::indices::IndexStream;
 
@@ -398,31 +398,31 @@ impl Encoder for DataCountSection {
 // ====== Module =======
 #[derive(Debug)]
 pub struct Module {
-    pub custom_section_before_type_section: Option<CustomSection>,
+    pub custom_section_before_type_section: Vec<CustomSection>,
     pub type_section: Option<TypeSection>,
-    pub custom_section_before_import_section: Option<CustomSection>,
+    pub custom_section_before_import_section: Vec<CustomSection>,
     pub import_section: Option<ImportSection>,
-    pub custom_section_before_function_section: Option<CustomSection>,
+    pub custom_section_before_function_section: Vec<CustomSection>,
     pub function_section: Option<FunctionSection>,
-    pub custom_section_before_table_section: Option<CustomSection>,
+    pub custom_section_before_table_section: Vec<CustomSection>,
     pub table_section: Option<TableSection>,
-    pub custom_section_before_memory_section: Option<CustomSection>,
+    pub custom_section_before_memory_section: Vec<CustomSection>,
     pub memory_section: Option<MemorySection>,
-    pub custom_section_before_globals_section: Option<CustomSection>,
+    pub custom_section_before_globals_section: Vec<CustomSection>,
     pub globals_section: Option<GlobalsSection>,
-    pub custom_section_before_export_section: Option<CustomSection>,
+    pub custom_section_before_export_section: Vec<CustomSection>,
     pub export_section: Option<ExportSection>,
-    pub custom_section_before_start_section: Option<CustomSection>,
+    pub custom_section_before_start_section: Vec<CustomSection>,
     pub start_section: Option<StartSection>,
-    pub custom_section_before_data_count_section: Option<CustomSection>,
+    pub custom_section_before_data_count_section: Vec<CustomSection>,
     pub data_count_section: Option<DataCountSection>,
-    pub custom_section_before_element_section: Option<CustomSection>,
+    pub custom_section_before_element_section: Vec<CustomSection>,
     pub element_section: Option<ElementSection>,
-    pub custom_section_before_code_section: Option<CustomSection>,
+    pub custom_section_before_code_section: Vec<CustomSection>,
     pub code_section: Option<CodeSection>,
-    pub custom_section_before_data_section: Option<CustomSection>,
+    pub custom_section_before_data_section: Vec<CustomSection>,
     pub data_section: Option<DataSection>,
-    pub custom_section_at_the_end: Option<CustomSection>,
+    pub custom_section_at_the_end: Vec<CustomSection>,
 }
 
 impl Module {
@@ -431,31 +431,31 @@ impl Module {
 
     pub fn empty() -> Self {
         Self {
-            custom_section_before_type_section: None,
+            custom_section_before_type_section: vec![],
             type_section: None,
-            custom_section_before_import_section: None,
+            custom_section_before_import_section: vec![],
             import_section: None,
-            custom_section_before_function_section: None,
+            custom_section_before_function_section: vec![],
             function_section: None,
-            custom_section_before_table_section: None,
+            custom_section_before_table_section: vec![],
             table_section: None,
-            custom_section_before_memory_section: None,
+            custom_section_before_memory_section: vec![],
             memory_section: None,
-            custom_section_before_globals_section: None,
+            custom_section_before_globals_section: vec![],
             globals_section: None,
-            custom_section_before_export_section: None,
+            custom_section_before_export_section: vec![],
             export_section: None,
-            custom_section_before_start_section: None,
+            custom_section_before_start_section: vec![],
             start_section: None,
-            custom_section_before_data_count_section: None,
+            custom_section_before_data_count_section: vec![],
             data_count_section: None,
-            custom_section_before_element_section: None,
+            custom_section_before_element_section: vec![],
             element_section: None,
-            custom_section_before_code_section: None,
+            custom_section_before_code_section: vec![],
             code_section: None,
-            custom_section_before_data_section: None,
+            custom_section_before_data_section: vec![],
             data_section: None,
-            custom_section_at_the_end: None,
+            custom_section_at_the_end: vec![],
         }
     }
 
@@ -467,160 +467,134 @@ impl Encoder for Module {
     type S =
         Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<Seq<
             HeaderBytes,
-            Option<<CustomSection as Encoder>::S>
+            Vector<<CustomSection as Encoder>::S>
         >,  Option<<TypeSection as Encoder>::S>
-        >,  Option<<CustomSection as Encoder>::S>
+        >,  Vector<<CustomSection as Encoder>::S>
         >,  Option<<ImportSection as Encoder>::S>
-        >,  Option<<CustomSection as Encoder>::S>
+        >,  Vector<<CustomSection as Encoder>::S>
         >,  Option<<FunctionSection as Encoder>::S>,
-        >,  Option<<CustomSection as Encoder>::S>
+        >,  Vector<<CustomSection as Encoder>::S>
         >,  Option<<TableSection as Encoder>::S>,
-        >,  Option<<CustomSection as Encoder>::S>
+        >,  Vector<<CustomSection as Encoder>::S>
         >,  Option<<MemorySection as Encoder>::S>,
-        >,  Option<<CustomSection as Encoder>::S>
+        >,  Vector<<CustomSection as Encoder>::S>
         >,  Option<<GlobalsSection as Encoder>::S>,
-        >,  Option<<CustomSection as Encoder>::S>
+        >,  Vector<<CustomSection as Encoder>::S>
         >,  Option<<ExportSection as Encoder>::S>,
-        >,  Option<<CustomSection as Encoder>::S>
+        >,  Vector<<CustomSection as Encoder>::S>
         >,  Option<<StartSection as Encoder>::S>,
-        >,  Option<<CustomSection as Encoder>::S>
+        >,  Vector<<CustomSection as Encoder>::S>
         >,  Option<<ElementSection as Encoder>::S>,
-        >,  Option<<CustomSection as Encoder>::S>
+        >,  Vector<<CustomSection as Encoder>::S>
         >,  Option<<DataCountSection as Encoder>::S>,
-        >,  Option<<CustomSection as Encoder>::S>
+        >,  Vector<<CustomSection as Encoder>::S>
         >,  Option<<CodeSection as Encoder>::S>,
-        >,  Option<<CustomSection as Encoder>::S>
+        >,  Vector<<CustomSection as Encoder>::S>
         >,  Option<<DataSection as Encoder>::S>,
-        >,  Option<<CustomSection as Encoder>::S>
+        >,  Vector<<CustomSection as Encoder>::S>
         >;
 
     fn emit(&self) -> Self::S {
         let header = bytes4(Module::MAGIC).seq(bytes4(Module::VERSION));
 
-        let custom_section_before_type_section = match &self.custom_section_before_type_section {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_before_type_section =
+            vector(self.custom_section_before_type_section.iter().map(|custom_section| custom_section.emit()).collect());
 
         let type_section = match &self.type_section {
             Some(type_section) => Some(type_section.emit()),
             None => None,
         };
 
-        let custom_section_before_import_section = match &self.custom_section_before_import_section {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_before_import_section = 
+            vector(self.custom_section_before_import_section.iter().map(|custom_section| custom_section.emit()).collect());
 
         let import_section = match &self.import_section {
             Some(import_section) => Some(import_section.emit()),
             None => None,
         };
 
-        let custom_section_before_function_section = match &self.custom_section_before_function_section {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_before_function_section = 
+            vector(self.custom_section_before_function_section.iter().map(|custom_section| custom_section.emit()).collect());
 
         let function_section = match &self.function_section {
             Some(type_indices) => Some(type_indices.emit()),
             None => None,
         };
 
-        let custom_section_before_table_section = match &self.custom_section_before_table_section {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_before_table_section = 
+            vector(self.custom_section_before_table_section.iter().map(|custom_section| custom_section.emit()).collect());
 
         let table_section = match &self.table_section {
             Some(table_section) => Some(table_section.emit()),
             None => None,
         };
 
-        let custom_section_before_memory_section = match &self.custom_section_before_memory_section {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_before_memory_section = 
+            vector(self.custom_section_before_memory_section.iter().map(|custom_section| custom_section.emit()).collect());
 
         let memory_section = match &self.memory_section {
             Some(memory_section) => Some(memory_section.emit()),
             None => None,
         };
 
-        let custom_section_before_globals_section = match &self.custom_section_before_globals_section {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_before_globals_section = 
+            vector(self.custom_section_before_globals_section.iter().map(|custom_section| custom_section.emit()).collect());
 
         let globals_section = match &self.globals_section {
             Some(globals_section) => Some(globals_section.emit()),
             None => None,
         };
 
-        let custom_section_before_export_section = match &self.custom_section_before_export_section {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_before_export_section = 
+            vector(self.custom_section_before_export_section.iter().map(|custom_section| custom_section.emit()).collect());
 
         let export_section = match &self.export_section {
             Some(exports) => Some(exports.emit()),
             None => None,
         };
 
-        let custom_section_before_start_section = match &self.custom_section_before_start_section {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_before_start_section = 
+            vector(self.custom_section_before_start_section.iter().map(|custom_section| custom_section.emit()).collect());
 
         let start_section = match &self.start_section {
             Some(start_section) => Some(start_section.emit()),
             None => None,
         };
 
-        let custom_section_before_element_section = match &self.custom_section_before_element_section {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_before_element_section = 
+            vector(self.custom_section_before_element_section.iter().map(|custom_section| custom_section.emit()).collect());
 
         let element_section = match &self.element_section {
             Some(element) => Some(element.emit()),
             None => None,
         };
 
-        let custom_section_before_data_count_section = match &self.custom_section_before_data_count_section {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_before_data_count_section = 
+            vector(self.custom_section_before_data_count_section.iter().map(|custom_section| custom_section.emit()).collect());
 
         let data_count_section = match &self.data_count_section {
             Some(data_count_section) => Some(data_count_section.emit()),
             None => None,
         };
 
-        let custom_section_before_code_section = match &self.custom_section_before_code_section {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_before_code_section = 
+            vector(self.custom_section_before_code_section.iter().map(|custom_section| custom_section.emit()).collect());
 
         let code_section = match &self.code_section {
             Some(code) => Some(code.emit()),
             None => None,
         };
 
-        let custom_section_before_data_section = match &self.custom_section_before_data_section {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_before_data_section = 
+            vector(self.custom_section_before_data_section.iter().map(|custom_section| custom_section.emit()).collect());
 
         let data_section = match &self.data_section {
             Some(data_section) => Some(data_section.emit()),
             None => None,
         };
 
-        let custom_section_at_the_end = match &self.custom_section_at_the_end {
-            Some(custom_section) => Some(custom_section.emit()),
-            None => None,
-        };
+        let custom_section_at_the_end = 
+            vector(self.custom_section_at_the_end.iter().map(|custom_section| custom_section.emit()).collect());
 
         header
             .seq(custom_section_before_type_section)

--- a/wasm/src/binary_format/sections.rs
+++ b/wasm/src/binary_format/sections.rs
@@ -594,7 +594,7 @@ impl Encoder for Module {
         };
 
         let custom_section_at_the_end = 
-            vector(self.custom_section_at_the_end.iter().map(|custom_section| custom_section.emit()).collect());
+            vector(self.custom_section_at_the_end.iter().map(|custom_section| { custom_section.emit() }).collect());
 
         header
             .seq(custom_section_before_type_section)

--- a/wasm/src/syntax.rs
+++ b/wasm/src/syntax.rs
@@ -1,9 +1,9 @@
 use crate::binary_format::sections;
-use crate::binary_format::sections::{TypeSection, FunctionSection, ExportSection, ImportSection, CodeSection, TableSection, MemorySection, TableType, ElementSection, Element};
+use crate::binary_format::sections::{TypeSection, FunctionSection, GlobalsSection, ExportSection, ImportSection, CodeSection, TableSection, MemorySection, TableType, ElementSection, Element, DataSection, DataItem};
 use crate::{Encoder, ByteStream};
 use crate::base::{
     indices::{TypeIndex, LocalIndex, GlobalIndex, LabelIndex, FunctionIndex, TableIndex, MemoryIndex},
-    types::{FunctionType, ValueType, BlockType, NumType, RefType},
+    types::{FunctionType, ValueType, BlockType, NumType, RefType, GlobalType},
     export::{Export, ExportDescription},
     import::{Import, ImportDescription},
     instructions,
@@ -16,8 +16,10 @@ pub struct Module {
     // performance friendly.
     functions: Vec<FunctionOrImport>,
     function_table: Vec<FunctionIndex>,
+    globals: Vec<Global>,
+    data_table: Vec<(i32, Vec<u8>)>, // TODO: I need the type of a pointer to memory...?
     exports: Vec<Export>,
-    memory_types: Vec<Limit>,
+    memories: Vec<MemoryOrImport>,
 }
 
 enum FunctionOrImport {
@@ -32,6 +34,11 @@ impl FunctionOrImport {
             Self::Fn(Function { type_index, .. }) => *type_index,
         }
     }
+}
+
+enum MemoryOrImport {
+    Memory(Limit),
+    Import(MemoryImport),
 }
 
 struct Function {
@@ -52,12 +59,23 @@ struct FunctionImport {
     type_index: TypeIndex,
 }
 
+pub struct MemoryImport {
+    pub module_name: String,
+    pub name: String,
+    pub limit: Limit,
+}
+
 pub struct TypedFunctionImport {
     pub module_name: String,
     pub name: String,
     pub type_: FunctionType,
 }
 
+#[derive(Debug)]
+pub struct Global {
+    pub global_type: GlobalType,
+    pub expression: Expression,
+}
 
 #[derive(Debug)]
 pub enum Expression {
@@ -218,7 +236,7 @@ enum FloatRel2 {
 
 impl Module {
     pub fn empty() -> Self {
-        Self { function_types: vec![], functions: vec![], exports: vec![], memory_types: vec![], function_table: vec![] }
+        Self { function_types: vec![], functions: vec![], exports: vec![], memories: vec![], function_table: vec![], data_table: vec![], globals: vec![], }
     }
 
     pub fn add_function_type(&mut self, fn_type: FunctionType) -> TypeIndex {
@@ -240,9 +258,21 @@ impl Module {
         fn_index
     }
 
+    pub fn add_global(&mut self, global: Global) -> GlobalIndex {
+        let global_index = GlobalIndex(self.globals.len() as u32);
+        self.globals.push(global);
+        global_index
+    }
+
     pub fn add_memory(&mut self, limit: Limit) -> MemoryIndex {
-        let memory_index = MemoryIndex(self.memory_types.len() as u32);
-        self.memory_types.push(limit);
+        let memory_index = MemoryIndex(self.memories.len() as u32);
+        self.memories.push(MemoryOrImport::Memory(limit));
+        memory_index
+    }
+
+    pub fn add_memory_import(&mut self, memory_import: MemoryImport) -> MemoryIndex {
+        let memory_index = MemoryIndex(self.memories.len() as u32);
+        self.memories.push(MemoryOrImport::Import(memory_import));
         memory_index
     }
 
@@ -266,6 +296,10 @@ impl Module {
         self.function_table = function_table
     }
 
+    pub fn register_data_table(&mut self, data_table: Vec<(i32, Vec<u8>)>) {
+        self.data_table = data_table
+    }
+
     pub fn binary_format(self) -> sections::Module {
         let mut bin_module = sections::Module::empty();
 
@@ -279,6 +313,14 @@ impl Module {
             Some(FunctionSection { type_indices: function_types_map })
         };
 
+        bin_module.memory_section = {
+            let memory_types = self.memories.iter().filter_map(|memory| match memory {
+                MemoryOrImport::Memory(limit) => Some(*limit),
+                MemoryOrImport::Import(_) => None,
+            }).collect();
+            Some(MemorySection { memory_types })
+        };
+
         bin_module.table_section = {
             let number_of_closures = self.function_table.len() as u32;
             let table_type = TableType {
@@ -290,18 +332,23 @@ impl Module {
 
         bin_module.import_section = {
             // TODO: Can this be done without cloning of strings?
-            let imports: Vec<Import> = self.functions.iter().filter_map(|fn_| match fn_ {
-                FunctionOrImport::Import(fn_import) => Some(Import { module_name: fn_import.module_name.clone(), name: fn_import.name.clone(), import_description: ImportDescription::FunctionTypeIndex(fn_import.type_index) }),
+            let mut imports: Vec<Import> = self.functions.iter().filter_map(|fn_| match fn_ {
+                FunctionOrImport::Import(fn_import) => Some(Import {
+                    module_name: fn_import.module_name.clone(),
+                    name: fn_import.name.clone(),
+                    import_description: ImportDescription::FunctionTypeIndex(fn_import.type_index) }),
                 FunctionOrImport::Fn(_) => None,
             }).collect();
 
-            //imports.push(Import {
-            //    module_name: "env".to_string(), name: "closure_table".to_string(),
-            //    import_description: {
-            //        let number_of_closures = self.function_table.len() as u32;
-            //        ImportDescription::TableType(RefType::FuncRef, Limit::MinMax { min: number_of_closures, max: number_of_closures })
-            //    }
-            //});
+            // TODO: Can this be done without cloning of strings?
+            imports.extend(self.memories.into_iter().filter_map(|memory| match memory {
+                MemoryOrImport::Import(memory_import) => Some(Import {
+                    module_name: memory_import.module_name.clone(), 
+                    name: memory_import.name.clone(), 
+                    import_description: ImportDescription::MemoryType(memory_import.limit)
+                }),
+                MemoryOrImport::Memory(_) => None,
+            }));
 
             Some(ImportSection { imports })
         };
@@ -321,8 +368,27 @@ impl Module {
             Some(CodeSection { codes })
         };
 
-        bin_module.memory_section = {
-            Some(MemorySection { memory_types: self.memory_types })
+        bin_module.data_section = {
+            let data_items = self.data_table.into_iter().map(|(_address, initialize)|
+                // To use Active Data segment, I need to compute memory offset.
+                // Unfortunately that won't compile, because I don't have memory imported in
+                // generated segment.
+                // I could try to import memory, but it seems wasm-merge doesn't allow me to do that,
+                // it will try to generate final wasm file with multiple memories.
+                // So it seems I can't import memory that's used in runtime.
+                // So instead I have an Active Data segment s.t. I will have to initialize the
+                // memory manually when the wasm module executes.
+                DataItem::Passive { initialize, }
+            ).collect();
+            Some(DataSection { data_items })
+        };
+
+        bin_module.globals_section = {
+            let globals = self.globals.into_iter().map(|global| sections::Global {
+                    global_type: global.global_type,
+                    expression: global.expression.binary_format(),
+            }).collect();
+            Some(GlobalsSection { globals })
         };
 
         bin_module.export_section = Some(ExportSection { exports: self.exports });


### PR DESCRIPTION
### Polymede Frontend
* `String` type
* String literals e.g. "hello, world", or "foo\nbar\nbaz", or "  \u{1f923}  😀   "
### Runtime
* Change encoding of tuples to include a tag in their header so that GC can distinguish them from strings/string slices
* Introduce a new STATIC region that's before the STACK. It will store all string literals for the duration of the program.
* String contents are encoded as contiguous valid utf8 vector of bytes on the HEAP/STATIC that are properly marked so that they can be GC'd (or not in case of STATIC)
* A capability for handling a string is basically a smart pointer/slice. Since we wish to have cheap substring slices, and ability to properly GC strings, we need a triple `(raw_pointer_to_start_of_original_string, raw_pointer_to_start_of_current_slice, length in bytes)`.
* Primitive operation `concat : String, String -> String` that copies and concatenates its input strings
* Primitive command `print : String -> Cmd(I32)`
### Encoding
* String Contents `| gc 1 byte | tag 1 byte | count 4 byte | string contents |`
* String Slice `| gc 1 byte | tag 1 byte | 1st pointer 4 byte | 2nd pointer 4 byte | count 4 byte |` 
* Tuple `| gc 1 byte | tag 1 byte | variant 4 bytes | count 1 byte | sequence of tagged pointers/constants, 5 bytes each |`
### Wasm Custom Sections
Since I'm using `wasm-merge` as a poor man's linker, I had to hack some stuff up with respect to initialization of STATIC region. For this wasm custom sections are needed.